### PR TITLE
Implement GUI-based text categorizer with ONNX runtime integration

### DIFF
--- a/categorizer/cluster.go
+++ b/categorizer/cluster.go
@@ -1,0 +1,85 @@
+package categorizer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type cluster struct {
+	repr    []float32
+	best    Hit
+	members []Hit
+}
+
+func clusterHits(hits []Hit, threshold float32) []Hit {
+	if len(hits) <= 1 || threshold <= 0 {
+		return hits
+	}
+	clusters := make([]cluster, 0, len(hits))
+	for _, h := range hits {
+		if len(h.Vector) == 0 {
+			clusters = append(clusters, cluster{repr: nil, best: h, members: []Hit{h}})
+			continue
+		}
+		assigned := false
+		for i := range clusters {
+			if len(clusters[i].repr) == 0 {
+				continue
+			}
+			if cosineSimilarity(h.Vector, clusters[i].repr) >= threshold {
+				clusters[i].members = append(clusters[i].members, h)
+				if h.Score > clusters[i].best.Score {
+					clusters[i].best = h
+					clusters[i].repr = cloneVector(h.Vector)
+				}
+				assigned = true
+				break
+			}
+		}
+		if !assigned {
+			clusters = append(clusters, cluster{
+				repr:    cloneVector(h.Vector),
+				best:    h,
+				members: []Hit{h},
+			})
+		}
+	}
+	out := make([]Hit, 0, len(clusters))
+	for _, c := range clusters {
+		if len(c.members) == 0 {
+			continue
+		}
+		label := c.best.Label
+		if len(c.members) > 1 {
+			extras := make([]string, 0, len(c.members)-1)
+			seen := map[string]struct{}{c.best.Label: {}}
+			for _, m := range c.members {
+				if m.Label == c.best.Label {
+					continue
+				}
+				if _, ok := seen[m.Label]; ok {
+					continue
+				}
+				seen[m.Label] = struct{}{}
+				extras = append(extras, m.Label)
+			}
+			if len(extras) > 0 {
+				label = fmt.Sprintf("%s（類似: %s）", label, strings.Join(extras, ", "))
+			}
+		}
+		out = append(out, Hit{
+			Label:  label,
+			Score:  c.best.Score,
+			Source: c.best.Source,
+			Vector: c.best.Vector,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Label < out[j].Label
+		}
+		return out[i].Score > out[j].Score
+	})
+	return out
+}

--- a/categorizer/config.go
+++ b/categorizer/config.go
@@ -1,0 +1,66 @@
+package categorizer
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const defaultConfigFile = "config.json"
+
+// LoadConfig loads configuration from the given path or the default config.json.
+func LoadConfig(path string) (Config, error) {
+	if path == "" {
+		path = defaultConfigFile
+	}
+	var cfg Config
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			cfg.UseNDC = true
+			cfg.ApplyDefaults()
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("read config: %w", err)
+	}
+	hasUseNDC := bytes.Contains(data, []byte("\"useNdc\""))
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("decode config: %w", err)
+	}
+	if !hasUseNDC {
+		cfg.UseNDC = true
+	}
+	cfg.ApplyDefaults()
+	if cfg.Embedder.CacheDir != "" {
+		if err := os.MkdirAll(cfg.Embedder.CacheDir, 0o755); err != nil {
+			return cfg, fmt.Errorf("create cache dir: %w", err)
+		}
+	}
+	return cfg, nil
+}
+
+// SaveConfig persists configuration to disk.
+func SaveConfig(path string, cfg Config) error {
+	if path == "" {
+		path = defaultConfigFile
+	}
+	tmp := path + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	cfg.ApplyDefaults()
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename config: %w", err)
+	}
+	return nil
+}

--- a/categorizer/embedder.go
+++ b/categorizer/embedder.go
@@ -1,0 +1,187 @@
+package categorizer
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"yashubustudio/categorizer/emb"
+)
+
+// Embedder exposes the minimal surface required by the service layer.
+type Embedder interface {
+	EmbedText(ctx context.Context, text string) ([]float32, error)
+	EmbedTexts(ctx context.Context, texts []string) ([][]float32, error)
+	Close() error
+	ModelID() string
+}
+
+// OrtEmbedder is a thin wrapper over emb.Encoder with caching.
+type OrtEmbedder struct {
+	enc      *emb.Encoder
+	cfg      EmbedderConfig
+	memCache map[string][]float32
+	mu       sync.RWMutex
+}
+
+// NewOrtEmbedder initializes the encoder and prepares cache directories.
+func NewOrtEmbedder(cfg EmbedderConfig) (*OrtEmbedder, error) {
+	if cfg.ModelID == "" && cfg.ModelPath != "" {
+		cfg.ModelID = filepath.Base(cfg.ModelPath)
+	}
+	if cfg.CacheDir != "" {
+		if err := os.MkdirAll(cfg.CacheDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create cache dir: %w", err)
+		}
+	}
+	encoder := &emb.Encoder{}
+	if err := encoder.Init(emb.Config{
+		OrtDLL:        cfg.OrtDLL,
+		ModelPath:     cfg.ModelPath,
+		TokenizerPath: cfg.TokenizerPath,
+		MaxSeqLen:     cfg.MaxSeqLen,
+	}); err != nil {
+		return nil, err
+	}
+	return &OrtEmbedder{
+		enc:      encoder,
+		cfg:      cfg,
+		memCache: make(map[string][]float32),
+	}, nil
+}
+
+// Close releases ORT resources.
+func (o *OrtEmbedder) Close() error {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.enc != nil {
+		o.enc.Close()
+		o.enc = nil
+	}
+	o.memCache = nil
+	return nil
+}
+
+// ModelID returns the identifier used for cache keys.
+func (o *OrtEmbedder) ModelID() string {
+	return o.cfg.ModelID
+}
+
+// EmbedText embeds a single string with caching.
+func (o *OrtEmbedder) EmbedText(_ context.Context, text string) ([]float32, error) {
+	if o == nil || o.enc == nil {
+		return nil, errors.New("embedder is not initialized")
+	}
+	normalized := NormalizeText(text)
+	key := o.cacheKey(normalized)
+	if vec := o.getFromCache(key); vec != nil {
+		return vec, nil
+	}
+	if vec, err := o.loadFromDisk(key); err == nil {
+		o.storeInMemory(key, vec)
+		return cloneVector(vec), nil
+	}
+	vec, err := o.enc.Encode(normalized)
+	if err != nil {
+		return nil, err
+	}
+	o.storeInMemory(key, vec)
+	_ = o.saveToDisk(key, vec)
+	return cloneVector(vec), nil
+}
+
+// EmbedTexts embeds a slice of strings sequentially.
+func (o *OrtEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		vec, err := o.EmbedText(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = vec
+	}
+	return out, nil
+}
+
+func (o *OrtEmbedder) cacheKey(text string) string {
+	h := sha1.New()
+	_, _ = io.WriteString(h, o.cfg.ModelID)
+	_, _ = io.WriteString(h, "|")
+	_, _ = io.WriteString(h, text)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (o *OrtEmbedder) getFromCache(key string) []float32 {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	if vec, ok := o.memCache[key]; ok {
+		return cloneVector(vec)
+	}
+	return nil
+}
+
+func (o *OrtEmbedder) storeInMemory(key string, vec []float32) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.memCache[key] = cloneVector(vec)
+}
+
+func (o *OrtEmbedder) loadFromDisk(key string) ([]float32, error) {
+	if o.cfg.CacheDir == "" {
+		return nil, os.ErrNotExist
+	}
+	path := filepath.Join(o.cfg.CacheDir, key+".bin")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 4 {
+		return nil, fmt.Errorf("cache file too small: %s", path)
+	}
+	length := int(binary.LittleEndian.Uint32(data[:4]))
+	data = data[4:]
+	if len(data) != length*4 {
+		return nil, fmt.Errorf("cache length mismatch: %s", path)
+	}
+	vec := make([]float32, length)
+	for i := 0; i < length; i++ {
+		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[i*4 : (i+1)*4]))
+	}
+	return vec, nil
+}
+
+func (o *OrtEmbedder) saveToDisk(key string, vec []float32) error {
+	if o.cfg.CacheDir == "" {
+		return nil
+	}
+	path := filepath.Join(o.cfg.CacheDir, key+".bin")
+	tmp := path + ".tmp"
+	buf := make([]byte, 4+len(vec)*4)
+	binary.LittleEndian.PutUint32(buf[:4], uint32(len(vec)))
+	off := 4
+	for _, v := range vec {
+		binary.LittleEndian.PutUint32(buf[off:off+4], math.Float32bits(v))
+		off += 4
+	}
+	if err := os.WriteFile(tmp, buf, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func cloneVector(vec []float32) []float32 {
+	out := make([]float32, len(vec))
+	copy(out, vec)
+	return out
+}

--- a/categorizer/index.go
+++ b/categorizer/index.go
@@ -1,0 +1,117 @@
+package categorizer
+
+import (
+	"math"
+	"sort"
+	"sync"
+)
+
+// VectorItem represents an entry within a vector index.
+type VectorItem struct {
+	Label  string
+	Source string
+	Vector []float32
+}
+
+// Hit is an internal structure used when combining scores.
+type Hit struct {
+	Label  string
+	Score  float32
+	Source string
+	Vector []float32
+}
+
+// VectorIndex provides nearest neighbour search capabilities.
+type VectorIndex interface {
+	Replace(items []VectorItem)
+	Search(vec []float32, k int) []Hit
+	Size() int
+}
+
+// InMemoryIndex is a brute-force vector index with cosine similarity.
+type InMemoryIndex struct {
+	mu    sync.RWMutex
+	items []VectorItem
+}
+
+// NewInMemoryIndex constructs an empty index.
+func NewInMemoryIndex() *InMemoryIndex {
+	return &InMemoryIndex{}
+}
+
+// Replace swaps the stored items atomically.
+func (idx *InMemoryIndex) Replace(items []VectorItem) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.items = make([]VectorItem, len(items))
+	for i, it := range items {
+		idx.items[i] = VectorItem{
+			Label:  it.Label,
+			Source: it.Source,
+			Vector: cloneVector(it.Vector),
+		}
+	}
+}
+
+// Size returns the current number of vectors stored.
+func (idx *InMemoryIndex) Size() int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return len(idx.items)
+}
+
+// Search performs cosine similarity against all stored items and returns the top-k hits.
+func (idx *InMemoryIndex) Search(vec []float32, k int) []Hit {
+	idx.mu.RLock()
+	items := idx.items
+	idx.mu.RUnlock()
+	if len(items) == 0 || len(vec) == 0 || k <= 0 {
+		return nil
+	}
+	hits := make([]Hit, 0, len(items))
+	for _, it := range items {
+		score := cosineSimilarity(vec, it.Vector)
+		hits = append(hits, Hit{
+			Label:  it.Label,
+			Score:  score,
+			Source: it.Source,
+			Vector: cloneVector(it.Vector),
+		})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		return hits[i].Score > hits[j].Score
+	})
+	if len(hits) > k {
+		hits = hits[:k]
+	}
+	return hits
+}
+
+func cosineSimilarity(a, b []float32) float32 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	var dot, na, nb float64
+	for i := 0; i < n; i++ {
+		fa := float64(a[i])
+		fb := float64(b[i])
+		dot += fa * fb
+		na += fa * fa
+		nb += fb * fb
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return float32(dot / (sqrtFloat64(na) * sqrtFloat64(nb)))
+}
+
+func sqrtFloat64(v float64) float64 {
+	return mathSqrt(v)
+}
+
+// mathSqrt is isolated for testing overrides (use math.Sqrt by default).
+var mathSqrt = func(v float64) float64 { return math.Sqrt(v) }

--- a/categorizer/io.go
+++ b/categorizer/io.go
@@ -1,0 +1,134 @@
+package categorizer
+
+import (
+	"bufio"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var textColumnCandidates = []string{"text", "本文", "content", "body", "message"}
+
+// ParseSeedFile reads the provided file and extracts seed labels using newline or comma separators.
+func ParseSeedFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open seed file: %w", err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read seed file: %w", err)
+	}
+	return parseSeedsFromString(string(data)), nil
+}
+
+// ParseSeeds converts raw string input into normalized seed labels.
+func ParseSeeds(data string) []string {
+	return parseSeedsFromString(data)
+}
+
+// parseSeedsFromString splits seed definitions by comma or newline.
+func parseSeedsFromString(data string) []string {
+	data = strings.ReplaceAll(data, "\r\n", "\n")
+	tokens := strings.FieldsFunc(data, func(r rune) bool {
+		return r == '\n' || r == ',' || r == ';'
+	})
+	out := make([]string, 0, len(tokens))
+	seen := make(map[string]struct{})
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		normalized := NormalizeText(token)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, token)
+	}
+	return out
+}
+
+// ParseTextFile reads a text/CSV/TSV file and extracts candidate sentences.
+func ParseTextFile(path string) ([]string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".csv":
+		return parseDelimited(path, ',')
+	case ".tsv":
+		return parseDelimited(path, '\t')
+	default:
+		return parsePlainText(path)
+	}
+}
+
+func parsePlainText(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open text file: %w", err)
+	}
+	defer f.Close()
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan text file: %w", err)
+	}
+	return out, nil
+}
+
+func parseDelimited(path string, comma rune) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+	reader := csv.NewReader(f)
+	reader.Comma = comma
+	reader.ReuseRecord = true
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	if len(rows) == 0 {
+		return nil, errors.New("empty file")
+	}
+	header := rows[0]
+	colIndex := -1
+	for i, col := range header {
+		for _, cand := range textColumnCandidates {
+			if strings.EqualFold(strings.TrimSpace(col), cand) {
+				colIndex = i
+				break
+			}
+		}
+		if colIndex >= 0 {
+			break
+		}
+	}
+	if colIndex < 0 {
+		return nil, fmt.Errorf("text column not found in %s", path)
+	}
+	out := make([]string, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		if colIndex >= len(row) {
+			continue
+		}
+		value := strings.TrimSpace(row[colIndex])
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out, nil
+}

--- a/categorizer/ndc.go
+++ b/categorizer/ndc.go
@@ -1,0 +1,37 @@
+package categorizer
+
+// NDCEntry represents a single entry in the embedded NDC dictionary.
+type NDCEntry struct {
+	Code  string
+	Label string
+}
+
+// DefaultNDCEntries returns the minimum viable dictionary based on NDC 10 major classes
+// and a few representative sub categories.
+func DefaultNDCEntries() []NDCEntry {
+	return []NDCEntry{
+		{Code: "000", Label: "総記"},
+		{Code: "100", Label: "哲学"},
+		{Code: "200", Label: "歴史"},
+		{Code: "300", Label: "社会科学"},
+		{Code: "400", Label: "自然科学"},
+		{Code: "500", Label: "技術・工学・工業"},
+		{Code: "600", Label: "産業"},
+		{Code: "700", Label: "芸術・美術"},
+		{Code: "800", Label: "言語"},
+		{Code: "900", Label: "文学"},
+		// Representative finer grained entries to provide better coverage
+		{Code: "007", Label: "情報科学"},
+		{Code: "336", Label: "経営"},
+		{Code: "657", Label: "会計"},
+		{Code: "910", Label: "日本文学"},
+		{Code: "913", Label: "日本小説"},
+		{Code: "930", Label: "外国文学"},
+		{Code: "320", Label: "法律"},
+		{Code: "360", Label: "社会問題"},
+		{Code: "610", Label: "農業"},
+		{Code: "620", Label: "工業"},
+		{Code: "830", Label: "英語"},
+		{Code: "910.26", Label: "近代文学"},
+	}
+}

--- a/categorizer/normalize.go
+++ b/categorizer/normalize.go
@@ -1,0 +1,34 @@
+package categorizer
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// NormalizeText performs Unicode normalization and trims whitespace.
+func NormalizeText(text string) string {
+	normed := norm.NFKC.String(text)
+	normed = strings.TrimSpace(normed)
+	// Collapse internal control characters except newlines.
+	normed = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, normed)
+	return normed
+}
+
+// NormalizeAll normalizes a slice of strings in place.
+func NormalizeAll(texts []string) []string {
+	out := make([]string, len(texts))
+	for i, t := range texts {
+		out[i] = NormalizeText(t)
+	}
+	return out
+}

--- a/categorizer/service.go
+++ b/categorizer/service.go
@@ -1,0 +1,256 @@
+package categorizer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Service orchestrates embedding, ranking and clustering based on the plan specification.
+type Service struct {
+	embedder Embedder
+
+	cfgMu sync.RWMutex
+	cfg   Config
+
+	seedsIdx *InMemoryIndex
+	ndcIdx   *InMemoryIndex
+
+	logger *log.Logger
+}
+
+// NewService constructs a service with the given embedder and configuration.
+func NewService(ctx context.Context, embedder Embedder, cfg Config, logger *log.Logger) (*Service, error) {
+	if embedder == nil {
+		return nil, errors.New("embedder is required")
+	}
+	cfg.ApplyDefaults()
+	s := &Service{
+		embedder: embedder,
+		cfg:      cfg,
+		seedsIdx: NewInMemoryIndex(),
+		ndcIdx:   NewInMemoryIndex(),
+		logger:   logger,
+	}
+	if cfg.UseNDC {
+		if err := s.LoadNDCDictionary(ctx, DefaultNDCEntries()); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// Close releases embedder resources.
+func (s *Service) Close() error {
+	if s.embedder != nil {
+		return s.embedder.Close()
+	}
+	return nil
+}
+
+// Config returns a copy of the current configuration.
+func (s *Service) Config() Config {
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	return s.cfg.Clone()
+}
+
+// UpdateConfig replaces the configuration.
+func (s *Service) UpdateConfig(cfg Config) {
+	cfg.ApplyDefaults()
+	s.cfgMu.Lock()
+	s.cfg = cfg
+	s.cfgMu.Unlock()
+}
+
+// LoadNDCDictionary embeds and stores the provided entries.
+func (s *Service) LoadNDCDictionary(ctx context.Context, entries []NDCEntry) error {
+	if len(entries) == 0 {
+		s.ndcIdx.Replace(nil)
+		s.logf("NDC dictionary cleared")
+		return nil
+	}
+	texts := make([]string, len(entries))
+	labels := make([]string, len(entries))
+	for i, entry := range entries {
+		normalized := NormalizeText(entry.Label)
+		texts[i] = fmt.Sprintf("%s %s", entry.Code, normalized)
+		labels[i] = fmt.Sprintf("%s:%s", entry.Code, normalized)
+	}
+	vecs, err := s.embedder.EmbedTexts(ctx, texts)
+	if err != nil {
+		return fmt.Errorf("embed ndc dictionary: %w", err)
+	}
+	items := make([]VectorItem, len(entries))
+	for i := range entries {
+		items[i] = VectorItem{
+			Label:  labels[i],
+			Source: "ndc",
+			Vector: vecs[i],
+		}
+	}
+	s.ndcIdx.Replace(items)
+	s.logf("Loaded %d NDC entries", len(items))
+	return nil
+}
+
+// LoadSeeds embeds the provided seed categories and replaces the current index.
+func (s *Service) LoadSeeds(ctx context.Context, seeds []string) error {
+	cleaned := make([]string, 0, len(seeds))
+	seen := make(map[string]struct{})
+	for _, seed := range seeds {
+		seed = strings.TrimSpace(seed)
+		if seed == "" {
+			continue
+		}
+		normalized := NormalizeText(seed)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		cleaned = append(cleaned, normalized)
+	}
+	if len(cleaned) == 0 {
+		s.seedsIdx.Replace(nil)
+		s.logf("Seed list cleared")
+		return nil
+	}
+	vecs, err := s.embedder.EmbedTexts(ctx, cleaned)
+	if err != nil {
+		return fmt.Errorf("embed seeds: %w", err)
+	}
+	items := make([]VectorItem, len(cleaned))
+	for i, label := range cleaned {
+		items[i] = VectorItem{
+			Label:  label,
+			Source: "seed",
+			Vector: vecs[i],
+		}
+	}
+	s.seedsIdx.Replace(items)
+	s.logf("Loaded %d seed categories", len(items))
+	return nil
+}
+
+// SeedCount returns how many seed categories are indexed.
+func (s *Service) SeedCount() int {
+	return s.seedsIdx.Size()
+}
+
+// ClassifyAll embeds all texts and returns ranked suggestions.
+func (s *Service) ClassifyAll(ctx context.Context, texts []string) ([]ResultRow, error) {
+	cfg := s.Config()
+	normTexts := NormalizeAll(texts)
+	vecs, err := s.embedder.EmbedTexts(ctx, normTexts)
+	if err != nil {
+		return nil, fmt.Errorf("embed texts: %w", err)
+	}
+	rows := make([]ResultRow, 0, len(texts))
+	for i, vec := range vecs {
+		rows = append(rows, s.rankForVector(vec, texts[i], cfg))
+	}
+	return rows, nil
+}
+
+func (s *Service) rankForVector(vec []float32, originalText string, cfg Config) ResultRow {
+	topK := cfg.TopK
+	if topK <= 0 {
+		topK = 3
+	}
+	seedHits := filterHits(s.seedsIdx.Search(vec, topK*3), cfg.MinScore)
+	ndcHits := filterHits(s.ndcIdx.Search(vec, topK*3), cfg.MinScore)
+
+	var suggestions []Suggestion
+	var ndcSuggestions []Suggestion
+
+	switch cfg.Mode {
+	case ModeSeeded:
+		if cfg.Cluster.Enabled {
+			seedHits = clusterHits(seedHits, cfg.Cluster.Threshold)
+		}
+		seedHits = limitHits(seedHits, topK)
+		suggestions = hitsToSuggestions(seedHits)
+	case ModeSplit:
+		if cfg.Cluster.Enabled {
+			seedHits = clusterHits(seedHits, cfg.Cluster.Threshold)
+			ndcHits = clusterHits(ndcHits, cfg.Cluster.Threshold)
+		}
+		suggestions = hitsToSuggestions(limitHits(seedHits, topK))
+		if cfg.UseNDC {
+			ndcSuggestions = hitsToSuggestions(limitHits(ndcHits, topK))
+		}
+	case ModeMixed:
+		weighted := make([]Hit, 0, len(seedHits)+len(ndcHits))
+		for _, h := range seedHits {
+			h.Score += cfg.SeedBias
+			weighted = append(weighted, h)
+		}
+		if cfg.UseNDC {
+			weighted = append(weighted, ndcHits...)
+		}
+		if cfg.Cluster.Enabled {
+			weighted = clusterHits(weighted, cfg.Cluster.Threshold)
+		}
+		sort.Slice(weighted, func(i, j int) bool {
+			if weighted[i].Score == weighted[j].Score {
+				return weighted[i].Label < weighted[j].Label
+			}
+			return weighted[i].Score > weighted[j].Score
+		})
+		suggestions = hitsToSuggestions(limitHits(weighted, topK))
+	default:
+		// Fallback to seeded behaviour if mode unknown.
+		if cfg.Cluster.Enabled {
+			seedHits = clusterHits(seedHits, cfg.Cluster.Threshold)
+		}
+		suggestions = hitsToSuggestions(limitHits(seedHits, topK))
+	}
+
+	return ResultRow{
+		Text:           originalText,
+		Suggestions:    suggestions,
+		NDCSuggestions: ndcSuggestions,
+	}
+}
+
+func filterHits(hits []Hit, minScore float32) []Hit {
+	if minScore <= 0 {
+		return hits
+	}
+	out := hits[:0]
+	for _, h := range hits {
+		if h.Score >= minScore {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func limitHits(hits []Hit, k int) []Hit {
+	if len(hits) <= k {
+		return hits
+	}
+	return hits[:k]
+}
+
+func hitsToSuggestions(hits []Hit) []Suggestion {
+	out := make([]Suggestion, len(hits))
+	for i, h := range hits {
+		out[i] = Suggestion{
+			Label:  h.Label,
+			Score:  h.Score,
+			Source: h.Source,
+		}
+	}
+	return out
+}
+
+func (s *Service) logf(format string, args ...any) {
+	if s.logger != nil {
+		s.logger.Printf(format, args...)
+	}
+}

--- a/categorizer/types.go
+++ b/categorizer/types.go
@@ -1,0 +1,87 @@
+package categorizer
+
+import "encoding/json"
+
+// Mode represents the ranking mode for suggestions.
+type Mode string
+
+const (
+	// ModeSeeded ranks only user provided seed categories.
+	ModeSeeded Mode = "seeded"
+	// ModeMixed ranks both seed categories and the NDC dictionary in a single list.
+	ModeMixed Mode = "mixed"
+	// ModeSplit keeps user seeds and NDC suggestions in separate lists.
+	ModeSplit Mode = "split"
+)
+
+// Suggestion represents an individual category suggestion.
+type Suggestion struct {
+	Label  string  `json:"label"`
+	Score  float32 `json:"score"`
+	Source string  `json:"source"`
+}
+
+// ResultRow holds the suggestions for a single input text.
+type ResultRow struct {
+	Text           string       `json:"text"`
+	Suggestions    []Suggestion `json:"suggestions"`
+	NDCSuggestions []Suggestion `json:"ndcSuggestions,omitempty"`
+}
+
+// ClusterConfig controls optional clustering of similar categories.
+type ClusterConfig struct {
+	Enabled   bool    `json:"enabled"`
+	Threshold float32 `json:"threshold"`
+}
+
+// EmbedderConfig wraps the configuration for the ORT embedder and cache.
+type EmbedderConfig struct {
+	OrtDLL        string `json:"ortDll"`
+	ModelPath     string `json:"modelPath"`
+	TokenizerPath string `json:"tokenizerPath"`
+	MaxSeqLen     int    `json:"maxSeqLen"`
+	CacheDir      string `json:"cacheDir"`
+	ModelID       string `json:"modelId"`
+}
+
+// Config aggregates runtime settings persisted to config.json.
+type Config struct {
+	Mode      Mode           `json:"mode"`
+	TopK      int            `json:"topK"`
+	SeedBias  float32        `json:"seedBias"`
+	MinScore  float32        `json:"minScore"`
+	Cluster   ClusterConfig  `json:"cluster"`
+	Embedder  EmbedderConfig `json:"embedder"`
+	SeedsPath string         `json:"seedsPath"`
+	UseNDC    bool           `json:"useNdc"`
+}
+
+// Clone creates a deep copy of the configuration so callers can mutate safely.
+func (c Config) Clone() Config {
+	buf, _ := json.Marshal(c)
+	var out Config
+	_ = json.Unmarshal(buf, &out)
+	return out
+}
+
+// ApplyDefaults populates zero values with sensible defaults.
+func (c *Config) ApplyDefaults() {
+	if c.Mode == "" {
+		c.Mode = ModeMixed
+	}
+	if c.TopK <= 0 {
+		c.TopK = 3
+	}
+	if c.SeedBias == 0 {
+		c.SeedBias = 0.03
+	}
+	if c.MinScore == 0 {
+		c.MinScore = 0.35
+	}
+	if c.Cluster.Threshold == 0 {
+		c.Cluster.Threshold = 0.8
+	}
+	if c.Embedder.MaxSeqLen == 0 {
+		c.Embedder.MaxSeqLen = 512
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,553 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/data/binding"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/widget"
+
+	"yashubustudio/categorizer/categorizer"
+)
+
+func main() {
+	fyneApp := app.NewWithID("yashubustudio.categorizer")
+	win := fyneApp.NewWindow("Categorizer (ベクトル検索支援)")
+	win.Resize(fyne.NewSize(1024, 768))
+
+	cfg, err := categorizer.LoadConfig("")
+	if err != nil {
+		showFatalError(win, fmt.Errorf("設定の読み込みに失敗しました: %w", err))
+		return
+	}
+
+	loggerBinding := binding.NewString()
+	logCapture := newLogCapture(loggerBinding, 300)
+	logger := log.New(io.MultiWriter(os.Stdout, logCapture), "", log.LstdFlags)
+
+	embedder, err := categorizer.NewOrtEmbedder(cfg.Embedder)
+	if err != nil {
+		logCapture.Write([]byte(fmt.Sprintf("[ERROR] %v\n", err)))
+		showFatalError(win, fmt.Errorf("埋め込みエンジンの初期化に失敗しました: %w", err))
+		return
+	}
+
+	ctx := context.Background()
+	service, err := categorizer.NewService(ctx, embedder, cfg, logger)
+	if err != nil {
+		showFatalError(win, fmt.Errorf("サービス初期化に失敗しました: %w", err))
+		return
+	}
+	defer service.Close()
+
+	var resultRows []categorizer.ResultRow
+	var resultMu sync.Mutex
+
+	cfgMu := sync.Mutex{}
+
+	saveConfig := func() {
+		cfgMu.Lock()
+		defer cfgMu.Unlock()
+		if err := categorizer.SaveConfig("", cfg); err != nil {
+			logger.Printf("設定の保存に失敗しました: %v", err)
+		}
+	}
+	defer saveConfig()
+
+	// Seed controls
+	seedInput := widget.NewMultiLineEntry()
+	seedInput.SetPlaceHolder("カテゴリシード（改行またはカンマ区切り）")
+	seedInput.Wrapping = fyne.TextWrapWord
+
+	seedStatus := widget.NewLabel("シード未設定")
+
+	applySeeds := func(seeds []string) {
+		seedStatus.SetText("シード更新中...")
+		if fyneApp.Driver() == nil {
+			if err := service.LoadSeeds(ctx, seeds); err != nil {
+				showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
+				return
+			}
+			seedStatus.SetText(fmt.Sprintf("シード数: %d", service.SeedCount()))
+			return
+		}
+		go func(list []string) {
+			if err := service.LoadSeeds(ctx, list); err != nil {
+				showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
+				return
+			}
+			fyneApp.Driver().CallOnMainThread(func() {
+				seedStatus.SetText(fmt.Sprintf("シード数: %d", service.SeedCount()))
+			})
+		}(seeds)
+	}
+
+	loadSeedsFromInput := func() {
+		seeds := categorizer.ParseSeeds(seedInput.Text)
+		cfgMu.Lock()
+		cfg.SeedsPath = ""
+		cfgMu.Unlock()
+		saveConfig()
+		applySeeds(seeds)
+	}
+
+	loadSeedsBtn := widget.NewButton("シード反映", loadSeedsFromInput)
+	loadSeedsFileBtn := widget.NewButton("シードファイル読込", func() {
+		fd := dialog.NewFileOpen(func(rc fyne.URIReadCloser, err error) {
+			if err != nil {
+				showError(win, err)
+				return
+			}
+			if rc == nil {
+				return
+			}
+			defer rc.Close()
+			path := rc.URI().Path()
+			seeds, err := categorizer.ParseSeedFile(path)
+			if err != nil {
+				showError(win, err)
+				return
+			}
+			seedInput.SetText(strings.Join(seeds, "\n"))
+			cfgMu.Lock()
+			cfg.SeedsPath = path
+			cfgMu.Unlock()
+			saveConfig()
+			applySeeds(seeds)
+		}, win)
+		fd.SetFilter(storageFilter([]string{".txt", ".csv", ".tsv"}))
+		fd.Show()
+	})
+
+	// Load seeds from config if path specified
+	if cfg.SeedsPath != "" {
+		if seeds, err := categorizer.ParseSeedFile(cfg.SeedsPath); err == nil {
+			seedInput.SetText(strings.Join(seeds, "\n"))
+			applySeeds(seeds)
+		} else {
+			logger.Printf("シードファイルの読み込みに失敗しました: %v", err)
+		}
+	}
+
+	// Text input controls
+	textInput := widget.NewMultiLineEntry()
+	textInput.SetPlaceHolder("分類したい文章を1行ずつ入力してください")
+	textInput.Wrapping = fyne.TextWrapWord
+
+	statusLabel := widget.NewLabel("準備完了")
+
+	var tableData [][]string
+	resultTable := widget.NewTable(
+		func() (int, int) {
+			if len(tableData) == 0 {
+				return 0, 0
+			}
+			return len(tableData), len(tableData[0])
+		},
+		func() fyne.CanvasObject {
+			return widget.NewLabel("")
+		},
+		func(id widget.TableCellID, obj fyne.CanvasObject) {
+			if len(tableData) == 0 || id.Row >= len(tableData) || id.Col >= len(tableData[id.Row]) {
+				return
+			}
+			label := obj.(*widget.Label)
+			label.SetText(tableData[id.Row][id.Col])
+			if id.Row == 0 {
+				label.TextStyle = fyne.TextStyle{Bold: true}
+			} else {
+				label.TextStyle = fyne.TextStyle{}
+			}
+		},
+	)
+	resultTable.OnSelected = func(id widget.TableCellID) {
+		if id.Row <= 0 {
+			return
+		}
+		resultMu.Lock()
+		if id.Row-1 < len(resultRows) {
+			row := resultRows[id.Row-1]
+			dialog.ShowInformation("詳細", fmt.Sprintf("本文:\n%s\n\n提案:\n%s", row.Text, formatSuggestions(row)), win)
+		}
+		resultMu.Unlock()
+	}
+
+	updateTable := func(rows []categorizer.ResultRow) {
+		resultMu.Lock()
+		resultRows = rows
+		resultMu.Unlock()
+		localCfg := service.Config()
+		includeNDC := localCfg.Mode == categorizer.ModeSplit && localCfg.UseNDC
+		tableData = buildTableData(rows, localCfg.TopK, includeNDC)
+		fyne.CurrentApp().Driver().CallOnMainThread(func() {
+			if len(tableData) > 0 {
+				for col := range tableData[0] {
+					width := float32(150)
+					if col == 0 {
+						width = 220
+					}
+					resultTable.SetColumnWidth(col, width)
+				}
+			}
+			resultTable.Refresh()
+		})
+	}
+
+	classifyBtn := widget.NewButton("分類実行", func() {
+		lines := parseInputTexts(textInput.Text)
+		if len(lines) == 0 {
+			showError(win, fmt.Errorf("入力文章がありません"))
+			return
+		}
+		classifyBtn.Disable()
+		statusLabel.SetText("推論中...")
+		go func(texts []string) {
+			start := time.Now()
+			rows, err := service.ClassifyAll(ctx, texts)
+			elapsed := time.Since(start)
+			if err != nil {
+				fyne.CurrentApp().Driver().CallOnMainThread(func() {
+					classifyBtn.Enable()
+					statusLabel.SetText("エラーが発生しました")
+					showError(win, err)
+				})
+				return
+			}
+			updateTable(rows)
+			fyne.CurrentApp().Driver().CallOnMainThread(func() {
+				classifyBtn.Enable()
+				statusLabel.SetText(fmt.Sprintf("%d件 %.2fs", len(rows), elapsed.Seconds()))
+			})
+		}(lines)
+	})
+
+	loadTextFileBtn := widget.NewButton("テキスト読込", func() {
+		fd := dialog.NewFileOpen(func(rc fyne.URIReadCloser, err error) {
+			if err != nil {
+				showError(win, err)
+				return
+			}
+			if rc == nil {
+				return
+			}
+			defer rc.Close()
+			path := rc.URI().Path()
+			texts, err := categorizer.ParseTextFile(path)
+			if err != nil {
+				showError(win, err)
+				return
+			}
+			textInput.SetText(strings.Join(texts, "\n"))
+		}, win)
+		fd.SetFilter(storageFilter([]string{".txt", ".csv", ".tsv"}))
+		fd.Show()
+	})
+
+	exportBtn := widget.NewButton("結果をCSV出力", func() {
+		if len(tableData) <= 1 {
+			showError(win, fmt.Errorf("出力する結果がありません"))
+			return
+		}
+		fd := dialog.NewFileSave(func(uc fyne.URIWriteCloser, err error) {
+			if err != nil {
+				showError(win, err)
+				return
+			}
+			if uc == nil {
+				return
+			}
+			defer uc.Close()
+			writer := csv.NewWriter(uc)
+			for _, row := range tableData {
+				if err := writer.Write(row); err != nil {
+					showError(win, err)
+					return
+				}
+			}
+			writer.Flush()
+			if err := writer.Error(); err != nil {
+				showError(win, err)
+				return
+			}
+		}, win)
+		fd.SetFileName("results.csv")
+		fd.SetFilter(storageFilter([]string{".csv"}))
+		fd.Show()
+	})
+
+	// Settings controls
+	modeSelect := widget.NewSelect([]string{string(categorizer.ModeSeeded), string(categorizer.ModeMixed), string(categorizer.ModeSplit)}, func(val string) {
+		cfgMu.Lock()
+		cfg.Mode = categorizer.Mode(val)
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	})
+	modeSelect.SetSelected(string(cfg.Mode))
+
+	topKSlider := widget.NewSlider(1, 5)
+	topKSlider.Step = 1
+	topKSlider.SetValue(float64(cfg.TopK))
+	topKLabel := widget.NewLabel(fmt.Sprintf("Top-K: %d", cfg.TopK))
+	topKSlider.OnChanged = func(v float64) {
+		k := int(v)
+		topKLabel.SetText(fmt.Sprintf("Top-K: %d", k))
+		cfgMu.Lock()
+		cfg.TopK = k
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	}
+
+	seedBiasSlider := widget.NewSlider(0, 0.2)
+	seedBiasSlider.Step = 0.01
+	seedBiasSlider.SetValue(float64(cfg.SeedBias))
+	seedBiasLabel := widget.NewLabel(fmt.Sprintf("シードバイアス: %.2f", cfg.SeedBias))
+	seedBiasSlider.OnChanged = func(v float64) {
+		seedBiasLabel.SetText(fmt.Sprintf("シードバイアス: %.2f", v))
+		cfgMu.Lock()
+		cfg.SeedBias = float32(v)
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	}
+
+	minScoreSlider := widget.NewSlider(0, 1)
+	minScoreSlider.Step = 0.01
+	minScoreSlider.SetValue(float64(cfg.MinScore))
+	minScoreLabel := widget.NewLabel(fmt.Sprintf("最小スコア: %.2f", cfg.MinScore))
+	minScoreSlider.OnChanged = func(v float64) {
+		minScoreLabel.SetText(fmt.Sprintf("最小スコア: %.2f", v))
+		cfgMu.Lock()
+		cfg.MinScore = float32(v)
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	}
+
+	clusterCheck := widget.NewCheck("類似カテゴリを束ねる", nil)
+	clusterCheck.SetChecked(cfg.Cluster.Enabled)
+
+	clusterSlider := widget.NewSlider(0.5, 0.95)
+	clusterSlider.Step = 0.01
+	clusterSlider.SetValue(float64(cfg.Cluster.Threshold))
+	clusterLabel := widget.NewLabel(fmt.Sprintf("クラスタ閾値: %.2f", cfg.Cluster.Threshold))
+	clusterSlider.OnChanged = func(v float64) {
+		clusterLabel.SetText(fmt.Sprintf("クラスタ閾値: %.2f", v))
+		cfgMu.Lock()
+		cfg.Cluster.Threshold = float32(v)
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	}
+	clusterSlider.Disable()
+	if cfg.Cluster.Enabled {
+		clusterSlider.Enable()
+	}
+	clusterCheck.OnChanged = func(checked bool) {
+		if checked {
+			clusterSlider.Enable()
+		} else {
+			clusterSlider.Disable()
+		}
+		cfgMu.Lock()
+		cfg.Cluster.Enabled = checked
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+	}
+
+	useNDCCheck := widget.NewCheck("NDC提案を使用", func(checked bool) {
+		cfgMu.Lock()
+		cfg.UseNDC = checked
+		localCfg := cfg
+		cfgMu.Unlock()
+		service.UpdateConfig(localCfg)
+		saveConfig()
+		go func() {
+			if checked {
+				if err := service.LoadNDCDictionary(ctx, categorizer.DefaultNDCEntries()); err != nil {
+					showError(win, err)
+				}
+			} else {
+				if err := service.LoadNDCDictionary(ctx, nil); err != nil {
+					showError(win, err)
+				}
+			}
+		}()
+	})
+	useNDCCheck.SetChecked(cfg.UseNDC)
+
+	logLabel := widget.NewLabelWithData(loggerBinding)
+	logLabel.Wrapping = fyne.TextWrapWord
+	logContainer := container.NewVScroll(logLabel)
+	logContainer.SetMinSize(fyne.NewSize(200, 120))
+
+	controls := container.NewVBox(
+		container.NewHBox(classifyBtn, loadTextFileBtn, exportBtn, statusLabel),
+		container.NewVBox(widget.NewLabel("テキスト入力"), textInput),
+		widget.NewSeparator(),
+		container.NewVBox(
+			widget.NewLabel("シードカテゴリ"),
+			seedInput,
+			container.NewHBox(loadSeedsBtn, loadSeedsFileBtn, seedStatus),
+		),
+		widget.NewSeparator(),
+		container.NewVBox(
+			widget.NewLabel("設定"),
+			modeSelect,
+			container.NewHBox(topKLabel, topKSlider),
+			container.NewHBox(seedBiasLabel, seedBiasSlider),
+			container.NewHBox(minScoreLabel, minScoreSlider),
+			container.NewHBox(clusterCheck, clusterLabel, clusterSlider),
+			useNDCCheck,
+		),
+		widget.NewSeparator(),
+		widget.NewLabel("ログ"),
+		logContainer,
+	)
+
+	root := container.NewHSplit(controls, container.NewVSplit(resultTable, widget.NewLabel("セルを選択すると詳細が表示されます")))
+	root.Offset = 0.45
+	win.SetContent(root)
+
+	win.ShowAndRun()
+}
+
+func showFatalError(win fyne.Window, err error) {
+	content := widget.NewLabel(err.Error())
+	win.SetContent(content)
+	dialog.ShowError(err, win)
+	win.ShowAndRun()
+}
+
+func showError(win fyne.Window, err error) {
+	if err != nil {
+		dialog.ShowError(err, win)
+	}
+}
+
+func storageFilter(exts []string) fyne.FileFilter {
+	return storage.NewExtensionFileFilter(exts)
+}
+
+func parseInputTexts(text string) []string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func buildTableData(rows []categorizer.ResultRow, topK int, includeNDC bool) [][]string {
+	header := []string{"text"}
+	for i := 1; i <= topK; i++ {
+		header = append(header, fmt.Sprintf("suggestion%d", i), fmt.Sprintf("score%d", i))
+	}
+	if includeNDC {
+		for i := 1; i <= topK; i++ {
+			header = append(header, fmt.Sprintf("ndc%d", i), fmt.Sprintf("ndcScore%d", i))
+		}
+	}
+	data := make([][]string, 1, len(rows)+1)
+	data[0] = header
+	for _, row := range rows {
+		rowData := make([]string, len(header))
+		rowData[0] = truncateText(row.Text, 100)
+		idx := 1
+		for i := 0; i < topK; i++ {
+			if i < len(row.Suggestions) {
+				rowData[idx] = row.Suggestions[i].Label
+				rowData[idx+1] = fmt.Sprintf("%.3f", row.Suggestions[i].Score)
+			}
+			idx += 2
+		}
+		if includeNDC {
+			for i := 0; i < topK; i++ {
+				if i < len(row.NDCSuggestions) {
+					rowData[idx] = row.NDCSuggestions[i].Label
+					rowData[idx+1] = fmt.Sprintf("%.3f", row.NDCSuggestions[i].Score)
+				}
+				idx += 2
+			}
+		}
+		data = append(data, rowData)
+	}
+	return data
+}
+
+func truncateText(text string, max int) string {
+	if len([]rune(text)) <= max {
+		return text
+	}
+	runes := []rune(text)
+	return string(runes[:max]) + "…"
+}
+
+func formatSuggestions(row categorizer.ResultRow) string {
+	var b strings.Builder
+	for i, s := range row.Suggestions {
+		fmt.Fprintf(&b, "[%d] %s (%.3f)\n", i+1, s.Label, s.Score)
+	}
+	if len(row.NDCSuggestions) > 0 {
+		b.WriteString("\nNDC:\n")
+		for i, s := range row.NDCSuggestions {
+			fmt.Fprintf(&b, "[%d] %s (%.3f)\n", i+1, s.Label, s.Score)
+		}
+	}
+	return b.String()
+}
+
+type logCapture struct {
+	mu      sync.Mutex
+	lines   []string
+	limit   int
+	binding binding.String
+}
+
+func newLogCapture(b binding.String, limit int) *logCapture {
+	return &logCapture{binding: b, limit: limit}
+}
+
+func (l *logCapture) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	text := string(p)
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	parts := strings.Split(text, "\n")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		l.lines = append(l.lines, part)
+	}
+	if len(l.lines) > l.limit {
+		l.lines = l.lines[len(l.lines)-l.limit:]
+	}
+	joined := strings.Join(l.lines, "\n")
+	_ = l.binding.Set(joined)
+	return len(p), nil
+}

--- a/onnxruntimetest.go
+++ b/onnxruntimetest.go
@@ -5,11 +5,17 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"yashubustudio/categorizer/emb"
 )
 
 func main() {
+	fmt.Println("このバイナリはGUIアプリの開発用に残されたONNX Runtimeサンプルです。")
+	fmt.Println("環境変数 RUN_ONNX_EXAMPLE=1 を指定すると旧来のデモを実行します。")
+	if os.Getenv("RUN_ONNX_EXAMPLE") != "1" {
+		return
+	}
 	enc := &emb.Encoder{}
 	cfg := emb.Config{
 		OrtDLL:        `D:\\Ollama\\projects\\csv-search\\onnixruntime-win\\lib\\onnxruntime.dll`,


### PR DESCRIPTION
## Summary
- add a categorizer package that wraps the ONNX encoder with caching, manages vector indices, clustering, and NDC dictionary loading for ranking results
- implement file parsing utilities and a Fyne-based desktop UI that supports text/seed ingestion, configuration controls, live logging, and CSV export of suggestions
- gate the legacy onnxruntimetest example behind an environment flag so the GUI main entry point can coexist with the sample encoder code

## Testing
- `go test ./...` *(fails: external module downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d32fea39308323afd3d6d73e06596d