### PR TITLE
Allow selecting CSV columns for categories and texts

### DIFF
--- a/categorizer/io.go
+++ b/categorizer/io.go
@@ -8,10 +8,42 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
-var textColumnCandidates = []string{"text", "本文", "content", "body", "message"}
+var (
+	textColumnCandidates     = []string{"text", "本文", "content", "body", "message", "発表抜粋"}
+	titleColumnCandidates    = []string{"title", "タイトル", "発表のタイトル", "題名", "名称"}
+	summaryColumnCandidates  = []string{"summary", "概要", "description", "発表の概要", "本文", "発表抜粋"}
+	indexColumnCandidates    = []string{"id", "index", "no", "番号", "発表インデックス"}
+	categoryColumnCandidates = []string{"カテゴリ", "カテゴリー", "category"}
+)
+
+// InputParseOptions allows callers to choose which CSV columns map to record fields.
+type InputParseOptions struct {
+	IndexColumn string
+	TitleColumn string
+	BodyColumn  string
+	TextColumn  string
+}
+
+// InputFileMetadata provides header information and automatic column suggestions.
+type InputFileMetadata struct {
+	Columns   []string
+	Suggested InputParseOptions
+}
+
+// CategoryParseOptions allows callers to select which column to use as category labels.
+type CategoryParseOptions struct {
+	Column string
+}
+
+// CategoryFileMetadata holds header data and the detected category column.
+type CategoryFileMetadata struct {
+	Columns   []string
+	Suggested string
+}
 
 // ParseSeedFile reads the provided file and extracts seed labels using newline or comma separators.
 func ParseSeedFile(path string) ([]string, error) {
@@ -55,32 +87,105 @@ func parseSeedsFromString(data string) []string {
 	return out
 }
 
-// ParseTextFile reads a text/CSV/TSV file and extracts candidate sentences.
-func ParseTextFile(path string) ([]string, error) {
+// ParseInputRecords reads a file and returns rich input records combining titles and bodies when available.
+func ParseInputRecords(path string) ([]InputRecord, error) {
+	return ParseInputRecordsWithOptions(path, InputParseOptions{})
+}
+
+// ParseInputRecordsWithOptions allows callers to specify column mappings when reading structured files.
+func ParseInputRecordsWithOptions(path string, opts InputParseOptions) ([]InputRecord, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".csv":
-		return parseDelimited(path, ',')
+		return parseDelimitedRecords(path, ',', opts)
 	case ".tsv":
-		return parseDelimited(path, '\t')
+		return parseDelimitedRecords(path, '\t', opts)
 	default:
-		return parsePlainText(path)
+		return parsePlainTextRecords(path)
 	}
 }
 
-func parsePlainText(path string) ([]string, error) {
+// ParseTextFile reads a text/CSV/TSV file and extracts combined texts for backward compatibility.
+func ParseTextFile(path string) ([]string, error) {
+	records, err := ParseInputRecordsWithOptions(path, InputParseOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(records))
+	for i, record := range records {
+		out[i] = record.Text
+	}
+	return out, nil
+}
+
+// ParseCategoryList extracts unique category labels from a CSV/TSV file.
+func ParseCategoryList(path string) ([]string, error) {
+	return ParseCategoryListWithOptions(path, CategoryParseOptions{})
+}
+
+// ParseCategoryListWithOptions extracts unique category labels honoring a caller provided column selection.
+func ParseCategoryListWithOptions(path string, opts CategoryParseOptions) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+	reader := csv.NewReader(f)
+	if strings.EqualFold(filepath.Ext(path), ".tsv") {
+		reader.Comma = '\t'
+	}
+	reader.FieldsPerRecord = -1
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	if len(rows) == 0 {
+		return nil, errors.New("empty category file")
+	}
+	header := make([]string, len(rows[0]))
+	for i, cell := range rows[0] {
+		header[i] = cleanCell(cell)
+	}
+	col, start, err := resolveCategoryColumn(header, opts.Column)
+	if err != nil {
+		return nil, err
+	}
+	categories := make([]string, 0, len(rows)-start)
+	seen := make(map[string]struct{})
+	for _, row := range rows[start:] {
+		if col >= len(row) {
+			continue
+		}
+		value := cleanCell(row[col])
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		categories = append(categories, value)
+	}
+	if len(categories) == 0 {
+		return nil, fmt.Errorf("no categories found in %s", path)
+	}
+	return categories, nil
+}
+
+func parsePlainTextRecords(path string) ([]InputRecord, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open text file: %w", err)
 	}
 	defer f.Close()
-	var out []string
+	var out []InputRecord
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			out = append(out, line)
+		line := cleanCell(scanner.Text())
+		if line == "" {
+			continue
 		}
+		out = append(out, InputRecord{Text: line, Body: line})
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan text file: %w", err)
@@ -88,7 +193,7 @@ func parsePlainText(path string) ([]string, error) {
 	return out, nil
 }
 
-func parseDelimited(path string, comma rune) ([]string, error) {
+func parseDelimitedRecords(path string, comma rune, opts InputParseOptions) ([]InputRecord, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", filepath.Base(path), err)
@@ -96,7 +201,7 @@ func parseDelimited(path string, comma rune) ([]string, error) {
 	defer f.Close()
 	reader := csv.NewReader(f)
 	reader.Comma = comma
-	reader.ReuseRecord = true
+	reader.FieldsPerRecord = -1
 	rows, err := reader.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
@@ -104,31 +209,302 @@ func parseDelimited(path string, comma rune) ([]string, error) {
 	if len(rows) == 0 {
 		return nil, errors.New("empty file")
 	}
-	header := rows[0]
-	colIndex := -1
-	for i, col := range header {
-		for _, cand := range textColumnCandidates {
-			if strings.EqualFold(strings.TrimSpace(col), cand) {
-				colIndex = i
-				break
-			}
-		}
-		if colIndex >= 0 {
-			break
-		}
+	header := make([]string, len(rows[0]))
+	for i, cell := range rows[0] {
+		header[i] = cleanCell(cell)
 	}
-	if colIndex < 0 {
-		return nil, fmt.Errorf("text column not found in %s", path)
+	resolved, skipHeader, err := resolveInputColumns(header, opts)
+	if err != nil {
+		return nil, err
 	}
-	out := make([]string, 0, len(rows)-1)
-	for _, row := range rows[1:] {
-		if colIndex >= len(row) {
+	start := 0
+	if skipHeader {
+		start = 1
+	}
+	records := make([]InputRecord, 0, len(rows)-start)
+	for _, row := range rows[start:] {
+		rec := InputRecord{}
+		if resolved.Index.Index >= 0 && resolved.Index.Index < len(row) {
+			rec.Index = cleanCell(row[resolved.Index.Index])
+		}
+		if resolved.Title.Index >= 0 && resolved.Title.Index < len(row) {
+			rec.Title = cleanCell(row[resolved.Title.Index])
+		}
+		var summaryVal string
+		if resolved.Body.Index >= 0 && resolved.Body.Index < len(row) {
+			summaryVal = cleanCell(row[resolved.Body.Index])
+		}
+		var textVal string
+		if resolved.Text.Index >= 0 && resolved.Text.Index < len(row) {
+			textVal = cleanCell(row[resolved.Text.Index])
+		}
+		if summaryVal == "" {
+			summaryVal = textVal
+		}
+		rec.Body = summaryVal
+		combined := combineParts(rec.Title, summaryVal)
+		if combined == "" {
+			combined = textVal
+		}
+		if combined == "" {
 			continue
 		}
-		value := strings.TrimSpace(row[colIndex])
-		if value != "" {
-			out = append(out, value)
+		if rec.Body == "" {
+			rec.Body = combined
+		}
+		rec.Text = combined
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+func cleanCell(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "\ufeff")
+	return v
+}
+
+func findColumn(header []string, candidates []string) int {
+	for i, col := range header {
+		for _, cand := range candidates {
+			if strings.EqualFold(col, cand) {
+				return i
+			}
 		}
 	}
-	return out, nil
+	return -1
+}
+
+func combineParts(title, body string) string {
+	var parts []string
+	if title != "" {
+		parts = append(parts, title)
+	}
+	if body != "" && body != title {
+		parts = append(parts, body)
+	}
+	return strings.Join(parts, "\n")
+}
+
+type columnResult struct {
+	Index      int
+	FromHeader bool
+	HeaderName string
+}
+
+type resolvedColumns struct {
+	Index columnResult
+	Title columnResult
+	Body  columnResult
+	Text  columnResult
+}
+
+func resolveInputColumns(header []string, opts InputParseOptions) (resolvedColumns, bool, error) {
+	res := resolvedColumns{
+		Index: columnResult{Index: -1},
+		Title: columnResult{Index: -1},
+		Body:  columnResult{Index: -1},
+		Text:  columnResult{Index: -1},
+	}
+	var err error
+	if res.Index, err = pickColumn(header, opts.IndexColumn, indexColumnCandidates); err != nil {
+		return res, false, err
+	}
+	if res.Title, err = pickColumn(header, opts.TitleColumn, titleColumnCandidates); err != nil {
+		return res, false, err
+	}
+	if res.Body, err = pickColumn(header, opts.BodyColumn, summaryColumnCandidates); err != nil {
+		return res, false, err
+	}
+	if res.Text, err = pickColumn(header, opts.TextColumn, textColumnCandidates); err != nil {
+		return res, false, err
+	}
+	skipHeader := res.Index.FromHeader || res.Title.FromHeader || res.Body.FromHeader || res.Text.FromHeader
+	if !skipHeader && res.Text.Index < 0 && len(header) > 0 {
+		res.Text.Index = 0
+		res.Text.FromHeader = false
+		res.Text.HeaderName = headerNameForIndex(header, res.Text.Index, false)
+	}
+	res.Index.HeaderName = headerNameForIndex(header, res.Index.Index, res.Index.FromHeader)
+	res.Title.HeaderName = headerNameForIndex(header, res.Title.Index, res.Title.FromHeader)
+	res.Body.HeaderName = headerNameForIndex(header, res.Body.Index, res.Body.FromHeader)
+	res.Text.HeaderName = headerNameForIndex(header, res.Text.Index, res.Text.FromHeader)
+	return res, skipHeader, nil
+}
+
+func pickColumn(header []string, explicit string, candidates []string) (columnResult, error) {
+	res := columnResult{Index: -1}
+	if strings.TrimSpace(explicit) != "" {
+		idx, fromHeader, err := matchExplicitColumn(header, explicit)
+		if err != nil {
+			return res, err
+		}
+		res.Index = idx
+		res.FromHeader = fromHeader
+		return res, nil
+	}
+	idx := findColumn(header, candidates)
+	if idx >= 0 {
+		res.Index = idx
+		res.FromHeader = true
+	}
+	return res, nil
+}
+
+func matchExplicitColumn(header []string, explicit string) (int, bool, error) {
+	trimmed := strings.TrimSpace(explicit)
+	if trimmed == "" {
+		return -1, false, nil
+	}
+	for i, col := range header {
+		if strings.EqualFold(col, trimmed) {
+			return i, true, nil
+		}
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		idx, err := parseColumnIndex(trimmed)
+		if err != nil {
+			return -1, false, err
+		}
+		if idx >= len(header) {
+			return -1, false, fmt.Errorf("column index %s is out of range", trimmed)
+		}
+		return idx, false, nil
+	}
+	return -1, false, fmt.Errorf("column %q not found", explicit)
+}
+
+func parseColumnIndex(token string) (int, error) {
+	trimmed := strings.TrimSpace(strings.TrimPrefix(token, "#"))
+	if trimmed == "" {
+		return -1, fmt.Errorf("invalid column index %q", token)
+	}
+	idx, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return -1, fmt.Errorf("invalid column index %q", token)
+	}
+	if idx <= 0 {
+		return -1, fmt.Errorf("column indices are 1-based: %q", token)
+	}
+	return idx - 1, nil
+}
+
+func headerNameForIndex(header []string, idx int, fromHeader bool) string {
+	if idx < 0 {
+		return ""
+	}
+	if fromHeader && idx < len(header) {
+		if name := header[idx]; name != "" {
+			return name
+		}
+	}
+	return fmt.Sprintf("#%d", idx+1)
+}
+
+func resolveCategoryColumn(header []string, explicit string) (int, int, error) {
+	trimmed := strings.TrimSpace(explicit)
+	if trimmed != "" {
+		idx, fromHeader, err := matchExplicitColumn(header, trimmed)
+		if err != nil {
+			return -1, 0, err
+		}
+		start := 0
+		if fromHeader {
+			start = 1
+		}
+		return idx, start, nil
+	}
+	col := findColumn(header, categoryColumnCandidates)
+	start := 0
+	if col >= 0 {
+		start = 1
+	} else if len(header) > 0 {
+		col = 0
+	}
+	if col < 0 {
+		return -1, 0, errors.New("no usable category column found")
+	}
+	return col, start, nil
+}
+
+// ReadInputFileMetadata returns header information and automatic suggestions for structured files.
+func ReadInputFileMetadata(path string) (InputFileMetadata, error) {
+	meta := InputFileMetadata{}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".csv" && ext != ".tsv" {
+		return meta, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return meta, fmt.Errorf("open %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+	reader := csv.NewReader(f)
+	if ext == ".tsv" {
+		reader.Comma = '\t'
+	}
+	reader.FieldsPerRecord = -1
+	row, err := reader.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return meta, nil
+		}
+		return meta, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	header := make([]string, len(row))
+	for i, cell := range row {
+		header[i] = cleanCell(cell)
+	}
+	meta.Columns = header
+	resolved, _, err := resolveInputColumns(header, InputParseOptions{})
+	if err == nil {
+		meta.Suggested = InputParseOptions{
+			IndexColumn: resolved.Index.HeaderName,
+			TitleColumn: resolved.Title.HeaderName,
+			BodyColumn:  resolved.Body.HeaderName,
+			TextColumn:  resolved.Text.HeaderName,
+		}
+	}
+	return meta, nil
+}
+
+// ReadCategoryFileMetadata returns header information and automatic suggestions for category files.
+func ReadCategoryFileMetadata(path string) (CategoryFileMetadata, error) {
+	meta := CategoryFileMetadata{}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".csv" && ext != ".tsv" {
+		return meta, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return meta, fmt.Errorf("open %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+	reader := csv.NewReader(f)
+	if ext == ".tsv" {
+		reader.Comma = '\t'
+	}
+	reader.FieldsPerRecord = -1
+	row, err := reader.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return meta, nil
+		}
+		return meta, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	header := make([]string, len(row))
+	for i, cell := range row {
+		header[i] = cleanCell(cell)
+	}
+	meta.Columns = header
+	col := findColumn(header, categoryColumnCandidates)
+	if col >= 0 {
+		meta.Suggested = header[col]
+		if meta.Suggested == "" {
+			meta.Suggested = fmt.Sprintf("#%d", col+1)
+		}
+	} else if len(header) > 0 {
+		meta.Suggested = fmt.Sprintf("#%d", 1)
+	}
+	return meta, nil
 }

--- a/categorizer/types.go
+++ b/categorizer/types.go
@@ -28,6 +28,14 @@ type ResultRow struct {
 	NDCSuggestions []Suggestion `json:"ndcSuggestions,omitempty"`
 }
 
+// InputRecord represents a text sample optionally accompanied by metadata.
+type InputRecord struct {
+	Index string `json:"index,omitempty"`
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+	Text  string `json:"text"`
+}
+
 // ClusterConfig controls optional clustering of similar categories.
 type ClusterConfig struct {
 	Enabled   bool    `json:"enabled"`

--- a/main.go
+++ b/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/csv"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -22,7 +25,98 @@ import (
 	"yashubustudio/categorizer/categorizer"
 )
 
+type displayResult struct {
+	Input  categorizer.InputRecord
+	Result categorizer.ResultRow
+}
+
 func main() {
+	batchInput := flag.String("batch-input", "", "CSV/TSV file containing texts to classify")
+	batchCategories := flag.String("category-file", "", "CSV/TSV file containing category labels")
+	batchOutputDir := flag.String("output-dir", "csv", "Directory where result_*.csv will be written")
+	inputIndexColumn := flag.String("input-index-column", "", "Column name or #index for the presentation index column")
+	inputTitleColumn := flag.String("input-title-column", "", "Column name or #index for the presentation title column")
+	inputBodyColumn := flag.String("input-body-column", "", "Column name or #index for the presentation body/summary column")
+	inputTextColumn := flag.String("input-text-column", "", "Column name or #index for the fallback text column")
+	categoryColumn := flag.String("category-column", "", "Column name or #index for category labels")
+	flag.Parse()
+
+	if *batchInput != "" {
+		inputOpts := categorizer.InputParseOptions{
+			IndexColumn: strings.TrimSpace(*inputIndexColumn),
+			TitleColumn: strings.TrimSpace(*inputTitleColumn),
+			BodyColumn:  strings.TrimSpace(*inputBodyColumn),
+			TextColumn:  strings.TrimSpace(*inputTextColumn),
+		}
+		if err := runBatchMode(
+			*batchInput,
+			*batchCategories,
+			*batchOutputDir,
+			inputOpts,
+			strings.TrimSpace(*categoryColumn),
+		); err != nil {
+			log.Fatalf("batch mode: %v", err)
+		}
+		return
+	}
+
+	runGUIMode()
+}
+
+func runBatchMode(inputPath, categoriesPath, outputDir string, inputOpts categorizer.InputParseOptions, categoryColumn string) error {
+	if categoriesPath == "" {
+		return errors.New("--category-file is required when using --batch-input")
+	}
+	cfg, err := categorizer.LoadConfig("")
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	cfg.TopK = 1
+
+	embedder, err := categorizer.NewOrtEmbedder(cfg.Embedder)
+	if err != nil {
+		return fmt.Errorf("init embedder: %w", err)
+	}
+	defer embedder.Close()
+
+	ctx := context.Background()
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+	service, err := categorizer.NewService(ctx, embedder, cfg, logger)
+	if err != nil {
+		return fmt.Errorf("init service: %w", err)
+	}
+	defer service.Close()
+
+	categories, err := categorizer.ParseCategoryListWithOptions(categoriesPath, categorizer.CategoryParseOptions{Column: categoryColumn})
+	if err != nil {
+		return fmt.Errorf("read category list: %w", err)
+	}
+	if err := service.LoadSeeds(ctx, categories); err != nil {
+		return fmt.Errorf("load categories: %w", err)
+	}
+
+	records, err := categorizer.ParseInputRecordsWithOptions(inputPath, inputOpts)
+	if err != nil {
+		return fmt.Errorf("read input records: %w", err)
+	}
+	if len(records) == 0 {
+		return errors.New("input file does not contain any texts")
+	}
+
+	rows, err := classifyRecords(ctx, service, records)
+	if err != nil {
+		return fmt.Errorf("classify: %w", err)
+	}
+
+	outputPath, err := saveResultsCSV(outputDir, records, rows)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("分類結果を %s に保存しました\n", outputPath)
+	return nil
+}
+
+func runGUIMode() {
 	fyneApp := app.NewWithID("yashubustudio.categorizer")
 	win := fyneApp.NewWindow("Categorizer (ベクトル検索支援)")
 	win.Resize(fyne.NewSize(1024, 768))
@@ -32,6 +126,7 @@ func main() {
 		showFatalError(win, fmt.Errorf("設定の読み込みに失敗しました: %w", err))
 		return
 	}
+	cfg.TopK = 1
 
 	loggerBinding := binding.NewString()
 	logCapture := newLogCapture(loggerBinding, 300)
@@ -52,11 +147,15 @@ func main() {
 	}
 	defer service.Close()
 
-	var resultRows []categorizer.ResultRow
-	var resultMu sync.Mutex
+	var (
+		displayResults    []displayResult
+		displayMu         sync.Mutex
+		pendingRecords    []categorizer.InputRecord
+		usePendingRecords bool
+		ignoreTextChange  bool
+	)
 
 	cfgMu := sync.Mutex{}
-
 	saveConfig := func() {
 		cfgMu.Lock()
 		defer cfgMu.Unlock()
@@ -66,7 +165,6 @@ func main() {
 	}
 	defer saveConfig()
 
-	// Seed controls
 	seedInput := widget.NewMultiLineEntry()
 	seedInput.SetPlaceHolder("カテゴリシード（改行またはカンマ区切り）")
 	seedInput.Wrapping = fyne.TextWrapWord
@@ -75,23 +173,19 @@ func main() {
 
 	applySeeds := func(seeds []string) {
 		seedStatus.SetText("シード更新中...")
-		if fyneApp.Driver() == nil {
-			if err := service.LoadSeeds(ctx, seeds); err != nil {
-				showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
-				return
-			}
-			seedStatus.SetText(fmt.Sprintf("シード数: %d", service.SeedCount()))
-			return
-		}
-		go func(list []string) {
-			if err := service.LoadSeeds(ctx, list); err != nil {
-				showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
+		list := append([]string(nil), seeds...)
+		go func(items []string) {
+			if err := service.LoadSeeds(ctx, items); err != nil {
+				fyne.Do(func() {
+					seedStatus.SetText("シード更新失敗")
+					showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
+				})
 				return
 			}
 			fyne.Do(func() {
 				seedStatus.SetText(fmt.Sprintf("シード数: %d", service.SeedCount()))
 			})
-		}(seeds)
+		}(list)
 	}
 
 	loadSeedsFromInput := func() {
@@ -115,25 +209,50 @@ func main() {
 			}
 			defer rc.Close()
 			path := rc.URI().Path()
+			ext := strings.ToLower(filepath.Ext(path))
+			applySeedsFromList := func(seeds []string) {
+				seedInput.SetText(strings.Join(seeds, "\n"))
+				cfgMu.Lock()
+				cfg.SeedsPath = path
+				cfgMu.Unlock()
+				saveConfig()
+				applySeeds(seeds)
+			}
+			if ext == ".csv" || ext == ".tsv" {
+				metadata, err := categorizer.ReadCategoryFileMetadata(path)
+				if err != nil {
+					showError(win, err)
+					return
+				}
+				showCategoryColumnSelector(win, path, metadata, func(column string, ok bool) {
+					if !ok {
+						return
+					}
+					seeds, err := categorizer.ParseCategoryListWithOptions(path, categorizer.CategoryParseOptions{Column: column})
+					if err != nil {
+						showError(win, err)
+						return
+					}
+					applySeedsFromList(seeds)
+				})
+				return
+			}
 			seeds, err := categorizer.ParseSeedFile(path)
 			if err != nil {
 				showError(win, err)
 				return
 			}
-			seedInput.SetText(strings.Join(seeds, "\n"))
-			cfgMu.Lock()
-			cfg.SeedsPath = path
-			cfgMu.Unlock()
-			saveConfig()
-			applySeeds(seeds)
+			applySeedsFromList(seeds)
 		}, win)
 		fd.SetFilter(storageFilter([]string{".txt", ".csv", ".tsv"}))
 		fd.Show()
 	})
 
-	// Load seeds from config if path specified
 	if cfg.SeedsPath != "" {
-		if seeds, err := categorizer.ParseSeedFile(cfg.SeedsPath); err == nil {
+		if seeds, err := categorizer.ParseCategoryListWithOptions(cfg.SeedsPath, categorizer.CategoryParseOptions{}); err == nil {
+			seedInput.SetText(strings.Join(seeds, "\n"))
+			applySeeds(seeds)
+		} else if seeds, err := categorizer.ParseSeedFile(cfg.SeedsPath); err == nil {
 			seedInput.SetText(strings.Join(seeds, "\n"))
 			applySeeds(seeds)
 		} else {
@@ -141,83 +260,117 @@ func main() {
 		}
 	}
 
-	// Text input controls
 	textInput := widget.NewMultiLineEntry()
 	textInput.SetPlaceHolder("分類したい文章を1行ずつ入力してください")
 	textInput.Wrapping = fyne.TextWrapWord
+	textInput.OnChanged = func(string) {
+		if ignoreTextChange {
+			return
+		}
+		usePendingRecords = false
+	}
 
 	statusLabel := widget.NewLabel("準備完了")
 
-	var tableData [][]string
-	resultTable := widget.NewTable(
-		func() (int, int) {
-			if len(tableData) == 0 {
-				return 0, 0
-			}
-			return len(tableData), len(tableData[0])
+	resultList := widget.NewList(
+		func() int {
+			displayMu.Lock()
+			defer displayMu.Unlock()
+			return len(displayResults)
 		},
 		func() fyne.CanvasObject {
-			return widget.NewLabel("")
+			header := widget.NewLabel("")
+			header.TextStyle = fyne.TextStyle{Bold: true}
+			header.Wrapping = fyne.TextWrapWord
+			summary := widget.NewLabel("")
+			summary.Wrapping = fyne.TextWrapWord
+			category := widget.NewLabel("")
+			category.TextStyle = fyne.TextStyle{Bold: true}
+			category.Wrapping = fyne.TextWrapWord
+			score := widget.NewLabel("")
+			score.Wrapping = fyne.TextWrapWord
+			return container.NewVBox(header, summary, category, score)
 		},
-		func(id widget.TableCellID, obj fyne.CanvasObject) {
-			if len(tableData) == 0 || id.Row >= len(tableData) || id.Col >= len(tableData[id.Row]) {
+		func(i widget.ListItemID, obj fyne.CanvasObject) {
+			displayMu.Lock()
+			defer displayMu.Unlock()
+			cont := obj.(*fyne.Container)
+			header := cont.Objects[0].(*widget.Label)
+			summary := cont.Objects[1].(*widget.Label)
+			category := cont.Objects[2].(*widget.Label)
+			score := cont.Objects[3].(*widget.Label)
+			if i < 0 || i >= len(displayResults) {
+				header.SetText("")
+				summary.SetText("")
+				summary.Hide()
+				category.SetText("")
+				score.SetText("")
+				score.Hide()
 				return
 			}
-			label := obj.(*widget.Label)
-			label.SetText(tableData[id.Row][id.Col])
-			if id.Row == 0 {
-				label.TextStyle = fyne.TextStyle{Bold: true}
+			item := displayResults[i]
+			header.SetText(formatDisplayHeader(item.Input))
+			summaryText := formatDisplaySummary(item.Input)
+			if summaryText == "" {
+				summary.Hide()
+				summary.SetText("")
 			} else {
-				label.TextStyle = fyne.TextStyle{}
+				summary.SetText(summaryText)
+				summary.Show()
+			}
+			if best, ok := pickBestSuggestion(item.Result); ok {
+				category.SetText(fmt.Sprintf("推定カテゴリ: %s", best.Label))
+				score.SetText(fmt.Sprintf("スコア: %.3f (source: %s)", best.Score, best.Source))
+				score.Show()
+			} else {
+				category.SetText("推定カテゴリ: (候補なし)")
+				score.SetText("")
+				score.Hide()
 			}
 		},
 	)
-	resultTable.OnSelected = func(id widget.TableCellID) {
-		if id.Row <= 0 {
+
+	resultList.OnSelected = func(id widget.ListItemID) {
+		displayMu.Lock()
+		defer displayMu.Unlock()
+		if id < 0 || id >= len(displayResults) {
 			return
 		}
-		resultMu.Lock()
-		if id.Row-1 < len(resultRows) {
-			row := resultRows[id.Row-1]
-			dialog.ShowInformation("詳細", fmt.Sprintf("本文:\n%s\n\n提案:\n%s", row.Text, formatSuggestions(row)), win)
-		}
-		resultMu.Unlock()
+		dialog.ShowInformation("詳細", buildDetailMessage(displayResults[id]), win)
 	}
 
-	updateTable := func(rows []categorizer.ResultRow) {
-		resultMu.Lock()
-		resultRows = rows
-		resultMu.Unlock()
-		localCfg := service.Config()
-		includeNDC := localCfg.Mode == categorizer.ModeSplit && localCfg.UseNDC
-		tableData = buildTableData(rows, localCfg.TopK, includeNDC)
+	updateResults := func(records []categorizer.InputRecord, rows []categorizer.ResultRow) {
+		limit := len(records)
+		if len(rows) < limit {
+			limit = len(rows)
+		}
+		recCopy := make([]categorizer.InputRecord, limit)
+		rowCopy := make([]categorizer.ResultRow, limit)
+		copy(recCopy, records[:limit])
+		copy(rowCopy, rows[:limit])
 		fyne.Do(func() {
-			if len(tableData) > 0 {
-				for col := range tableData[0] {
-					width := float32(150)
-					if col == 0 {
-						width = 220
-					}
-					resultTable.SetColumnWidth(col, width)
-				}
+			displayMu.Lock()
+			defer displayMu.Unlock()
+			displayResults = make([]displayResult, limit)
+			for i := 0; i < limit; i++ {
+				displayResults[i] = displayResult{Input: recCopy[i], Result: rowCopy[i]}
 			}
-			resultTable.Refresh()
+			resultList.Refresh()
 		})
 	}
 
 	var classifyBtn *widget.Button
-	classifyBtn = widget.NewButton("分類実行", func() {
-		lines := parseInputTexts(textInput.Text)
-		if len(lines) == 0 {
+	runClassification := func(records []categorizer.InputRecord) {
+		if len(records) == 0 {
 			showError(win, fmt.Errorf("入力文章がありません"))
 			return
 		}
 		classifyBtn.Disable()
 		statusLabel.SetText("推論中...")
-		go func(texts []string) {
+		localRecords := append([]categorizer.InputRecord(nil), records...)
+		go func(samples []categorizer.InputRecord) {
 			start := time.Now()
-			rows, err := service.ClassifyAll(ctx, texts)
-			elapsed := time.Since(start)
+			rows, err := classifyRecords(ctx, service, samples)
 			if err != nil {
 				fyne.Do(func() {
 					classifyBtn.Enable()
@@ -226,12 +379,27 @@ func main() {
 				})
 				return
 			}
-			updateTable(rows)
+			updateResults(samples, rows)
 			fyne.Do(func() {
 				classifyBtn.Enable()
-				statusLabel.SetText(fmt.Sprintf("%d件 %.2fs", len(rows), elapsed.Seconds()))
+				statusLabel.SetText(fmt.Sprintf("%d件 %.2fs", len(rows), time.Since(start).Seconds()))
 			})
-		}(lines)
+		}(localRecords)
+	}
+
+	classifyBtn = widget.NewButton("分類実行", func() {
+		var records []categorizer.InputRecord
+		if usePendingRecords && len(pendingRecords) > 0 {
+			records = append([]categorizer.InputRecord(nil), pendingRecords...)
+		} else {
+			lines := parseInputTexts(textInput.Text)
+			if len(lines) == 0 {
+				showError(win, fmt.Errorf("入力文章がありません"))
+				return
+			}
+			records = manualRecordsFromLines(lines)
+		}
+		runClassification(records)
 	})
 
 	loadTextFileBtn := widget.NewButton("テキスト読込", func() {
@@ -245,19 +413,45 @@ func main() {
 			}
 			defer rc.Close()
 			path := rc.URI().Path()
-			texts, err := categorizer.ParseTextFile(path)
+			metadata, err := categorizer.ReadInputFileMetadata(path)
 			if err != nil {
 				showError(win, err)
 				return
 			}
-			textInput.SetText(strings.Join(texts, "\n"))
+			showInputColumnSelector(win, path, metadata, func(opts categorizer.InputParseOptions, ok bool) {
+				if !ok {
+					statusLabel.SetText("操作をキャンセルしました")
+					return
+				}
+				records, err := categorizer.ParseInputRecordsWithOptions(path, opts)
+				if err != nil {
+					showError(win, err)
+					statusLabel.SetText("入力読込エラー")
+					return
+				}
+				if len(records) == 0 {
+					showError(win, fmt.Errorf("入力が空です"))
+					statusLabel.SetText("入力が空です")
+					return
+				}
+				preview := buildPreviewText(records)
+				ignoreTextChange = true
+				textInput.SetText(preview)
+				ignoreTextChange = false
+				pendingRecords = records
+				usePendingRecords = true
+				statusLabel.SetText(fmt.Sprintf("%s から %d 件読み込みました", filepath.Base(path), len(records)))
+			})
 		}, win)
 		fd.SetFilter(storageFilter([]string{".txt", ".csv", ".tsv"}))
 		fd.Show()
 	})
 
 	exportBtn := widget.NewButton("結果をCSV出力", func() {
-		if len(tableData) <= 1 {
+		displayMu.Lock()
+		count := len(displayResults)
+		displayMu.Unlock()
+		if count == 0 {
 			showError(win, fmt.Errorf("出力する結果がありません"))
 			return
 		}
@@ -271,7 +465,10 @@ func main() {
 			}
 			defer uc.Close()
 			writer := csv.NewWriter(uc)
-			for _, row := range tableData {
+			displayMu.Lock()
+			data := buildResultRecordsFromDisplay(displayResults)
+			displayMu.Unlock()
+			for _, row := range data {
 				if err := writer.Write(row); err != nil {
 					showError(win, err)
 					return
@@ -288,7 +485,159 @@ func main() {
 		fd.Show()
 	})
 
-	// Settings controls
+	var batchBtn *widget.Button
+	batchBtn = widget.NewButton("CSV一括分類", func() {
+		batchBtn.Disable()
+		statusLabel.SetText("カテゴリ一覧を選択してください")
+		catDialog := dialog.NewFileOpen(func(catRC fyne.URIReadCloser, err error) {
+			if err != nil {
+				showError(win, err)
+				batchBtn.Enable()
+				statusLabel.SetText("エラーが発生しました")
+				return
+			}
+			if catRC == nil {
+				batchBtn.Enable()
+				statusLabel.SetText("操作をキャンセルしました")
+				return
+			}
+			catPath := catRC.URI().Path()
+			catRC.Close()
+			metadata, err := categorizer.ReadCategoryFileMetadata(catPath)
+			if err != nil {
+				showError(win, err)
+				batchBtn.Enable()
+				statusLabel.SetText("カテゴリ一覧の読み込みに失敗しました")
+				return
+			}
+			showCategoryColumnSelector(win, catPath, metadata, func(column string, ok bool) {
+				if !ok {
+					batchBtn.Enable()
+					statusLabel.SetText("操作をキャンセルしました")
+					return
+				}
+				statusLabel.SetText("カテゴリ一覧を読み込み中...")
+				go func(catPath string, column string) {
+					categories, err := categorizer.ParseCategoryListWithOptions(catPath, categorizer.CategoryParseOptions{Column: column})
+					if err != nil {
+						fyne.Do(func() {
+							showError(win, err)
+							batchBtn.Enable()
+							statusLabel.SetText("カテゴリ一覧の読み込みに失敗しました")
+						})
+						return
+					}
+					if len(categories) == 0 {
+						fyne.Do(func() {
+							showError(win, fmt.Errorf("カテゴリが見つかりません"))
+							batchBtn.Enable()
+							statusLabel.SetText("カテゴリ一覧の読み込みに失敗しました")
+						})
+						return
+					}
+					fyne.Do(func() {
+						statusLabel.SetText("発表CSV/TSVを選択してください")
+					})
+					fyne.Do(func() {
+						recDialog := dialog.NewFileOpen(func(recRC fyne.URIReadCloser, err error) {
+							if err != nil {
+								showError(win, err)
+								batchBtn.Enable()
+								statusLabel.SetText("エラーが発生しました")
+								return
+							}
+							if recRC == nil {
+								batchBtn.Enable()
+								statusLabel.SetText("操作をキャンセルしました")
+								return
+							}
+							recPath := recRC.URI().Path()
+							recRC.Close()
+							inputMeta, err := categorizer.ReadInputFileMetadata(recPath)
+							if err != nil {
+								showError(win, err)
+								batchBtn.Enable()
+								statusLabel.SetText("入力読込エラー")
+								return
+							}
+							showInputColumnSelector(win, recPath, inputMeta, func(inputOpts categorizer.InputParseOptions, ok bool) {
+								if !ok {
+									batchBtn.Enable()
+									statusLabel.SetText("操作をキャンセルしました")
+									return
+								}
+								go func(cat []string, catPath, recPath string, opts categorizer.InputParseOptions) {
+									defer fyne.Do(func() { batchBtn.Enable() })
+									fyne.Do(func() { statusLabel.SetText("分類の準備中...") })
+									if err := service.LoadSeeds(ctx, cat); err != nil {
+										fyne.Do(func() {
+											statusLabel.SetText("シード読み込みエラー")
+											showError(win, fmt.Errorf("シードの読み込みに失敗しました: %w", err))
+										})
+										return
+									}
+									records, err := categorizer.ParseInputRecordsWithOptions(recPath, opts)
+									if err != nil {
+										fyne.Do(func() {
+											statusLabel.SetText("入力読込エラー")
+											showError(win, err)
+										})
+										return
+									}
+									if len(records) == 0 {
+										fyne.Do(func() {
+											statusLabel.SetText("入力が空です")
+											showError(win, fmt.Errorf("入力が空です"))
+										})
+										return
+									}
+									start := time.Now()
+									rows, err := classifyRecords(ctx, service, records)
+									if err != nil {
+										fyne.Do(func() {
+											statusLabel.SetText("分類エラー")
+											showError(win, err)
+										})
+										return
+									}
+									outputPath, err := saveResultsCSV("csv", records, rows)
+									if err != nil {
+										fyne.Do(func() {
+											statusLabel.SetText("保存エラー")
+											showError(win, err)
+										})
+										return
+									}
+									preview := buildPreviewText(records)
+									updateResults(records, rows)
+									fyne.Do(func() {
+										seedStatus.SetText(fmt.Sprintf("シード数: %d", service.SeedCount()))
+										seedInput.SetText(strings.Join(cat, "\n"))
+										cfgMu.Lock()
+										cfg.SeedsPath = catPath
+										cfgMu.Unlock()
+										saveConfig()
+										ignoreTextChange = true
+										textInput.SetText(preview)
+										ignoreTextChange = false
+										pendingRecords = records
+										usePendingRecords = true
+										statusLabel.SetText(fmt.Sprintf("%d件 %.2fs (保存: %s)", len(rows), time.Since(start).Seconds(), filepath.Base(outputPath)))
+										dialog.ShowInformation("分類完了", fmt.Sprintf("分類結果を %s に保存しました。", outputPath), win)
+									})
+								}(append([]string(nil), categories...), catPath, recPath, inputOpts)
+							})
+						}, win)
+						recDialog.SetFilter(storageFilter([]string{".csv", ".tsv"}))
+						recDialog.Show()
+					})
+				}(catPath, column)
+			})
+		}, win)
+		catDialog.SetFilter(storageFilter([]string{".csv", ".tsv"}))
+		catDialog.Show()
+	})
+
 	modeSelect := widget.NewSelect([]string{string(categorizer.ModeSeeded), string(categorizer.ModeMixed), string(categorizer.ModeSplit)}, func(val string) {
 		cfgMu.Lock()
 		cfg.Mode = categorizer.Mode(val)
@@ -299,20 +648,7 @@ func main() {
 	})
 	modeSelect.SetSelected(string(cfg.Mode))
 
-	topKSlider := widget.NewSlider(1, 5)
-	topKSlider.Step = 1
-	topKSlider.SetValue(float64(cfg.TopK))
-	topKLabel := widget.NewLabel(fmt.Sprintf("Top-K: %d", cfg.TopK))
-	topKSlider.OnChanged = func(v float64) {
-		k := int(v)
-		topKLabel.SetText(fmt.Sprintf("Top-K: %d", k))
-		cfgMu.Lock()
-		cfg.TopK = k
-		localCfg := cfg
-		cfgMu.Unlock()
-		service.UpdateConfig(localCfg)
-		saveConfig()
-	}
+	topKLabel := widget.NewLabel("Top-K: 1 (固定)")
 
 	seedBiasSlider := widget.NewSlider(0, 0.2)
 	seedBiasSlider.Step = 0.01
@@ -402,35 +738,178 @@ func main() {
 	logContainer := container.NewVScroll(logLabel)
 	logContainer.SetMinSize(fyne.NewSize(200, 120))
 
+	buttonRow := container.NewGridWithColumns(2, classifyBtn, loadTextFileBtn, exportBtn, batchBtn)
+
 	controls := container.NewVBox(
-		container.NewHBox(classifyBtn, loadTextFileBtn, exportBtn, statusLabel),
-		container.NewVBox(widget.NewLabel("テキスト入力"), textInput),
+		widget.NewLabel("テキスト入力"),
+		textInput,
+		buttonRow,
+		statusLabel,
 		widget.NewSeparator(),
-		container.NewVBox(
-			widget.NewLabel("シードカテゴリ"),
-			seedInput,
-			container.NewHBox(loadSeedsBtn, loadSeedsFileBtn, seedStatus),
-		),
+		widget.NewLabel("シードカテゴリ"),
+		seedInput,
+		container.NewHBox(loadSeedsBtn, loadSeedsFileBtn, seedStatus),
 		widget.NewSeparator(),
-		container.NewVBox(
-			widget.NewLabel("設定"),
-			modeSelect,
-			container.NewHBox(topKLabel, topKSlider),
-			container.NewHBox(seedBiasLabel, seedBiasSlider),
-			container.NewHBox(minScoreLabel, minScoreSlider),
-			container.NewHBox(clusterCheck, clusterLabel, clusterSlider),
-			useNDCCheck,
-		),
+		widget.NewLabel("設定"),
+		modeSelect,
+		topKLabel,
+		container.NewHBox(seedBiasLabel, seedBiasSlider),
+		container.NewHBox(minScoreLabel, minScoreSlider),
+		container.NewHBox(clusterCheck, clusterLabel, clusterSlider),
+		useNDCCheck,
 		widget.NewSeparator(),
 		widget.NewLabel("ログ"),
 		logContainer,
 	)
 
-	root := container.NewHSplit(controls, container.NewVSplit(resultTable, widget.NewLabel("セルを選択すると詳細が表示されます")))
-	root.Offset = 0.45
+	infoLabel := widget.NewLabel("項目を選択すると詳細が表示されます")
+	infoLabel.Wrapping = fyne.TextWrapWord
+	rightPanel := container.NewBorder(nil, infoLabel, nil, nil, resultList)
+
+	root := container.NewHSplit(controls, rightPanel)
+	root.Offset = 0.42
 	win.SetContent(root)
 
 	win.ShowAndRun()
+}
+
+type columnChoice struct {
+	Display string
+	Value   string
+}
+
+func buildColumnChoices(columns []string, blankLabel string) []columnChoice {
+	choices := make([]columnChoice, 0, len(columns)+1)
+	if blankLabel != "" {
+		choices = append(choices, columnChoice{Display: blankLabel, Value: ""})
+	}
+	for i, col := range columns {
+		displayName := col
+		if displayName == "" {
+			displayName = fmt.Sprintf("列%d", i+1)
+		}
+		display := fmt.Sprintf("%s (列%d)", displayName, i+1)
+		value := col
+		if value == "" {
+			value = fmt.Sprintf("#%d", i+1)
+		}
+		choices = append(choices, columnChoice{Display: display, Value: value})
+	}
+	return choices
+}
+
+func choiceDisplays(choices []columnChoice) []string {
+	labels := make([]string, len(choices))
+	for i, c := range choices {
+		labels[i] = c.Display
+	}
+	return labels
+}
+
+func findChoiceByValue(choices []columnChoice, value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	for _, c := range choices {
+		if c.Value == value {
+			return c.Display, true
+		}
+	}
+	return "", false
+}
+
+func choiceValue(choices []columnChoice, selected string) string {
+	selected = strings.TrimSpace(selected)
+	for _, c := range choices {
+		if c.Display == selected {
+			return strings.TrimSpace(c.Value)
+		}
+	}
+	return ""
+}
+
+func showInputColumnSelector(win fyne.Window, path string, metadata categorizer.InputFileMetadata, onComplete func(categorizer.InputParseOptions, bool)) {
+	if len(metadata.Columns) == 0 {
+		onComplete(categorizer.InputParseOptions{}, true)
+		return
+	}
+	indexChoices := buildColumnChoices(metadata.Columns, "未使用")
+	titleChoices := buildColumnChoices(metadata.Columns, "未使用")
+	bodyChoices := buildColumnChoices(metadata.Columns, "未使用")
+	textChoices := buildColumnChoices(metadata.Columns, "自動選択")
+
+	indexSelect := widget.NewSelect(choiceDisplays(indexChoices), nil)
+	indexSelect.PlaceHolder = "未使用"
+	if display, ok := findChoiceByValue(indexChoices, metadata.Suggested.IndexColumn); ok {
+		indexSelect.SetSelected(display)
+	}
+
+	titleSelect := widget.NewSelect(choiceDisplays(titleChoices), nil)
+	titleSelect.PlaceHolder = "未使用"
+	if display, ok := findChoiceByValue(titleChoices, metadata.Suggested.TitleColumn); ok {
+		titleSelect.SetSelected(display)
+	}
+
+	bodySelect := widget.NewSelect(choiceDisplays(bodyChoices), nil)
+	bodySelect.PlaceHolder = "未使用"
+	if display, ok := findChoiceByValue(bodyChoices, metadata.Suggested.BodyColumn); ok {
+		bodySelect.SetSelected(display)
+	}
+
+	textSelect := widget.NewSelect(choiceDisplays(textChoices), nil)
+	textSelect.PlaceHolder = "自動選択"
+	if display, ok := findChoiceByValue(textChoices, metadata.Suggested.TextColumn); ok {
+		textSelect.SetSelected(display)
+	}
+
+	description := widget.NewLabel(fmt.Sprintf("%s の列を選択してください。空欄は自動判定になります。", filepath.Base(path)))
+	description.Wrapping = fyne.TextWrapWord
+	form := widget.NewForm(
+		widget.NewFormItem("インデックス列", indexSelect),
+		widget.NewFormItem("タイトル列", titleSelect),
+		widget.NewFormItem("本文列", bodySelect),
+		widget.NewFormItem("テキスト列", textSelect),
+	)
+
+	content := container.NewVBox(description, widget.NewSeparator(), form)
+	dialog := dialog.NewCustomConfirm("列の選択", "OK", "キャンセル", content, func(ok bool) {
+		if !ok {
+			onComplete(categorizer.InputParseOptions{}, false)
+			return
+		}
+		opts := categorizer.InputParseOptions{
+			IndexColumn: choiceValue(indexChoices, indexSelect.Selected),
+			TitleColumn: choiceValue(titleChoices, titleSelect.Selected),
+			BodyColumn:  choiceValue(bodyChoices, bodySelect.Selected),
+			TextColumn:  choiceValue(textChoices, textSelect.Selected),
+		}
+		onComplete(opts, true)
+	}, win)
+	dialog.Resize(fyne.NewSize(420, 340))
+	dialog.Show()
+}
+
+func showCategoryColumnSelector(win fyne.Window, path string, metadata categorizer.CategoryFileMetadata, onComplete func(string, bool)) {
+	if len(metadata.Columns) == 0 {
+		onComplete("", true)
+		return
+	}
+	choices := buildColumnChoices(metadata.Columns, "自動選択")
+	selectWidget := widget.NewSelect(choiceDisplays(choices), nil)
+	selectWidget.PlaceHolder = "自動選択"
+	if display, ok := findChoiceByValue(choices, metadata.Suggested); ok {
+		selectWidget.SetSelected(display)
+	}
+	description := widget.NewLabel(fmt.Sprintf("%s からカテゴリ列を選択してください。", filepath.Base(path)))
+	description.Wrapping = fyne.TextWrapWord
+	content := container.NewVBox(description, widget.NewSeparator(), selectWidget)
+	dialog := dialog.NewCustomConfirm("カテゴリ列の選択", "OK", "キャンセル", content, func(ok bool) {
+		if !ok {
+			onComplete("", false)
+			return
+		}
+		onComplete(choiceValue(choices, selectWidget.Selected), true)
+	}, win)
+	dialog.Resize(fyne.NewSize(360, 240))
+	dialog.Show()
 }
 
 func showFatalError(win fyne.Window, err error) {
@@ -463,41 +942,177 @@ func parseInputTexts(text string) []string {
 	return out
 }
 
-func buildTableData(rows []categorizer.ResultRow, topK int, includeNDC bool) [][]string {
-	header := []string{"text"}
-	for i := 1; i <= topK; i++ {
-		header = append(header, fmt.Sprintf("suggestion%d", i), fmt.Sprintf("score%d", i))
+func classifyRecords(ctx context.Context, service *categorizer.Service, records []categorizer.InputRecord) ([]categorizer.ResultRow, error) {
+	texts := make([]string, len(records))
+	for i, rec := range records {
+		texts[i] = rec.Text
 	}
-	if includeNDC {
-		for i := 1; i <= topK; i++ {
-			header = append(header, fmt.Sprintf("ndc%d", i), fmt.Sprintf("ndcScore%d", i))
+	return service.ClassifyAll(ctx, texts)
+}
+
+func buildResultRecords(records []categorizer.InputRecord, rows []categorizer.ResultRow) [][]string {
+	data := make([][]string, 0, len(records)+1)
+	header := []string{"発表インデックス", "発表のタイトル", "発表の概要", "推定カテゴリ", "スコア"}
+	data = append(data, header)
+	for i, rec := range records {
+		body := rec.Body
+		if body == "" {
+			body = rec.Text
 		}
-	}
-	data := make([][]string, 1, len(rows)+1)
-	data[0] = header
-	for _, row := range rows {
-		rowData := make([]string, len(header))
-		rowData[0] = truncateText(row.Text, 100)
-		idx := 1
-		for i := 0; i < topK; i++ {
-			if i < len(row.Suggestions) {
-				rowData[idx] = row.Suggestions[i].Label
-				rowData[idx+1] = fmt.Sprintf("%.3f", row.Suggestions[i].Score)
-			}
-			idx += 2
-		}
-		if includeNDC {
-			for i := 0; i < topK; i++ {
-				if i < len(row.NDCSuggestions) {
-					rowData[idx] = row.NDCSuggestions[i].Label
-					rowData[idx+1] = fmt.Sprintf("%.3f", row.NDCSuggestions[i].Score)
-				}
-				idx += 2
+		label := ""
+		score := ""
+		if i < len(rows) {
+			if best, ok := pickBestSuggestion(rows[i]); ok {
+				label = best.Label
+				score = fmt.Sprintf("%.3f", best.Score)
 			}
 		}
-		data = append(data, rowData)
+		data = append(data, []string{rec.Index, rec.Title, body, label, score})
 	}
 	return data
+}
+
+func saveResultsCSV(outputDir string, records []categorizer.InputRecord, rows []categorizer.ResultRow) (string, error) {
+	if len(records) != len(rows) {
+		return "", fmt.Errorf("records/results length mismatch: %d vs %d", len(records), len(rows))
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return "", fmt.Errorf("create output dir: %w", err)
+	}
+	filename := fmt.Sprintf("result_%s.csv", time.Now().Format("200601021504"))
+	path := filepath.Join(outputDir, filename)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create result file: %w", err)
+	}
+	defer f.Close()
+	writer := csv.NewWriter(f)
+	data := buildResultRecords(records, rows)
+	for _, row := range data {
+		if err := writer.Write(row); err != nil {
+			return "", fmt.Errorf("write result: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", fmt.Errorf("flush result: %w", err)
+	}
+	return path, nil
+}
+
+func pickBestSuggestion(row categorizer.ResultRow) (categorizer.Suggestion, bool) {
+	if len(row.Suggestions) > 0 {
+		return row.Suggestions[0], true
+	}
+	if len(row.NDCSuggestions) > 0 {
+		return row.NDCSuggestions[0], true
+	}
+	return categorizer.Suggestion{}, false
+}
+
+func formatDisplayHeader(rec categorizer.InputRecord) string {
+	var parts []string
+	if rec.Index != "" {
+		parts = append(parts, fmt.Sprintf("#%s", rec.Index))
+	}
+	if rec.Title != "" {
+		parts = append(parts, rec.Title)
+	}
+	if len(parts) == 0 {
+		return truncateText(rec.Text, 60)
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatDisplaySummary(rec categorizer.InputRecord) string {
+	body := rec.Body
+	if body == "" {
+		body = rec.Text
+	}
+	if rec.Title != "" && body == rec.Title {
+		return ""
+	}
+	return body
+}
+
+func buildDetailMessage(item displayResult) string {
+	var b strings.Builder
+	if item.Input.Index != "" {
+		fmt.Fprintf(&b, "インデックス: %s\n", item.Input.Index)
+	}
+	if item.Input.Title != "" {
+		fmt.Fprintf(&b, "タイトル: %s\n\n", item.Input.Title)
+	}
+	body := formatDisplaySummary(item.Input)
+	if body == "" {
+		body = item.Input.Text
+	}
+	fmt.Fprintf(&b, "本文:\n%s\n\n", body)
+	if best, ok := pickBestSuggestion(item.Result); ok {
+		fmt.Fprintf(&b, "推定カテゴリ: %s (%.3f)\n", best.Label, best.Score)
+		fmt.Fprintf(&b, "ソース: %s\n", best.Source)
+	} else {
+		b.WriteString("推定カテゴリ: 候補なし\n")
+	}
+	if len(item.Result.Suggestions) > 0 {
+		b.WriteString("\nシード候補:\n")
+		for i, s := range item.Result.Suggestions {
+			fmt.Fprintf(&b, "  [%d] %s (%.3f)\n", i+1, s.Label, s.Score)
+		}
+	}
+	if len(item.Result.NDCSuggestions) > 0 {
+		b.WriteString("\nNDC候補:\n")
+		for i, s := range item.Result.NDCSuggestions {
+			fmt.Fprintf(&b, "  [%d] %s (%.3f)\n", i+1, s.Label, s.Score)
+		}
+	}
+	return b.String()
+}
+
+func manualRecordsFromLines(lines []string) []categorizer.InputRecord {
+	records := make([]categorizer.InputRecord, len(lines))
+	for i, line := range lines {
+		records[i] = categorizer.InputRecord{
+			Body: line,
+			Text: line,
+		}
+	}
+	return records
+}
+
+func buildPreviewText(records []categorizer.InputRecord) string {
+	parts := make([]string, 0, len(records))
+	for _, rec := range records {
+		var b strings.Builder
+		if rec.Title != "" {
+			b.WriteString(rec.Title)
+		}
+		body := rec.Body
+		if body == "" {
+			body = rec.Text
+		}
+		if body != "" && body != rec.Title {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(body)
+		}
+		if b.Len() == 0 {
+			b.WriteString(rec.Text)
+		}
+		parts = append(parts, b.String())
+	}
+	return strings.Join(parts, "\n---\n")
+}
+
+func buildResultRecordsFromDisplay(results []displayResult) [][]string {
+	records := make([]categorizer.InputRecord, len(results))
+	rows := make([]categorizer.ResultRow, len(results))
+	for i, item := range results {
+		records[i] = item.Input
+		rows[i] = item.Result
+	}
+	return buildResultRecords(records, rows)
 }
 
 func truncateText(text string, max int) string {


### PR DESCRIPTION
## Summary
- add parsing options and metadata helpers so CSV/TSV readers can honor explicit column selections and detect headers automatically
- extend the CLI and GUI flows to accept optional column names/indices for categories and inputs, including dialogs to pick columns when opening files
- provide reusable UI helpers for column selection and reuse the detection when loading seed files or batch-running classifications

## Testing
- go test ./... *(fails: dependency downloads are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d340afca18832399e56e25dde88b2e