### PR TITLE
Allow configuring CSV column detection

### DIFF
--- a/categorizer/columns.go
+++ b/categorizer/columns.go
@@ -1,0 +1,84 @@
+package categorizer
+
+import "sync"
+
+// ColumnCandidates defines possible header names for auto-detecting CSV/TSV columns.
+type ColumnCandidates struct {
+	Text     []string `json:"text"`
+	Title    []string `json:"title"`
+	Body     []string `json:"body"`
+	Index    []string `json:"index"`
+	Category []string `json:"category"`
+}
+
+var (
+	columnCandidatesMu  sync.RWMutex
+	activeColumnOptions = defaultColumnCandidates()
+)
+
+func defaultColumnCandidates() ColumnCandidates {
+	return ColumnCandidates{
+		Text:     []string{"text", "本文", "content", "body", "message", "発表抜粋"},
+		Title:    []string{"title", "タイトル", "発表のタイトル", "題名", "名称"},
+		Body:     []string{"summary", "概要", "description", "発表の概要", "本文", "発表抜粋"},
+		Index:    []string{"id", "index", "no", "番号", "発表インデックス"},
+		Category: []string{"カテゴリ", "カテゴリー", "category"},
+	}
+}
+
+// DefaultColumnCandidates returns the built-in column detection candidates.
+func DefaultColumnCandidates() ColumnCandidates {
+	return defaultColumnCandidates().clone()
+}
+
+// SetColumnCandidates updates the column detection candidates used during auto-detection.
+// Fields left nil fall back to the built-in defaults, allowing callers to override only
+// the parts they need.
+func SetColumnCandidates(candidates ColumnCandidates) {
+	columnCandidatesMu.Lock()
+	defer columnCandidatesMu.Unlock()
+	activeColumnOptions = candidates.withDefaults()
+}
+
+func getColumnCandidates() ColumnCandidates {
+	columnCandidatesMu.RLock()
+	defer columnCandidatesMu.RUnlock()
+	return activeColumnOptions.clone()
+}
+
+func (c ColumnCandidates) withDefaults() ColumnCandidates {
+	defaults := defaultColumnCandidates()
+	return ColumnCandidates{
+		Text:     pickStrings(c.Text, defaults.Text),
+		Title:    pickStrings(c.Title, defaults.Title),
+		Body:     pickStrings(c.Body, defaults.Body),
+		Index:    pickStrings(c.Index, defaults.Index),
+		Category: pickStrings(c.Category, defaults.Category),
+	}
+}
+
+func (c ColumnCandidates) clone() ColumnCandidates {
+	return ColumnCandidates{
+		Text:     cloneStrings(c.Text),
+		Title:    cloneStrings(c.Title),
+		Body:     cloneStrings(c.Body),
+		Index:    cloneStrings(c.Index),
+		Category: cloneStrings(c.Category),
+	}
+}
+
+func pickStrings(custom, fallback []string) []string {
+	if custom == nil {
+		return cloneStrings(fallback)
+	}
+	return cloneStrings(custom)
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}

--- a/categorizer/config.go
+++ b/categorizer/config.go
@@ -22,6 +22,7 @@ func LoadConfig(path string) (Config, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			cfg.UseNDC = true
 			cfg.ApplyDefaults()
+			SetColumnCandidates(cfg.ColumnCandidates)
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("read config: %w", err)
@@ -34,6 +35,7 @@ func LoadConfig(path string) (Config, error) {
 		cfg.UseNDC = true
 	}
 	cfg.ApplyDefaults()
+	SetColumnCandidates(cfg.ColumnCandidates)
 	if cfg.Embedder.CacheDir != "" {
 		if err := os.MkdirAll(cfg.Embedder.CacheDir, 0o755); err != nil {
 			return cfg, fmt.Errorf("create cache dir: %w", err)
@@ -52,6 +54,7 @@ func SaveConfig(path string, cfg Config) error {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 	cfg.ApplyDefaults()
+	SetColumnCandidates(cfg.ColumnCandidates)
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode config: %w", err)

--- a/categorizer/io.go
+++ b/categorizer/io.go
@@ -12,14 +12,6 @@ import (
 	"strings"
 )
 
-var (
-	textColumnCandidates     = []string{"text", "本文", "content", "body", "message", "発表抜粋"}
-	titleColumnCandidates    = []string{"title", "タイトル", "発表のタイトル", "題名", "名称"}
-	summaryColumnCandidates  = []string{"summary", "概要", "description", "発表の概要", "本文", "発表抜粋"}
-	indexColumnCandidates    = []string{"id", "index", "no", "番号", "発表インデックス"}
-	categoryColumnCandidates = []string{"カテゴリ", "カテゴリー", "category"}
-)
-
 // InputParseOptions allows callers to choose which CSV columns map to record fields.
 type InputParseOptions struct {
 	IndexColumn string
@@ -307,16 +299,17 @@ func resolveInputColumns(header []string, opts InputParseOptions) (resolvedColum
 		Text:  columnResult{Index: -1},
 	}
 	var err error
-	if res.Index, err = pickColumn(header, opts.IndexColumn, indexColumnCandidates); err != nil {
+	candidates := getColumnCandidates()
+	if res.Index, err = pickColumn(header, opts.IndexColumn, candidates.Index); err != nil {
 		return res, false, err
 	}
-	if res.Title, err = pickColumn(header, opts.TitleColumn, titleColumnCandidates); err != nil {
+	if res.Title, err = pickColumn(header, opts.TitleColumn, candidates.Title); err != nil {
 		return res, false, err
 	}
-	if res.Body, err = pickColumn(header, opts.BodyColumn, summaryColumnCandidates); err != nil {
+	if res.Body, err = pickColumn(header, opts.BodyColumn, candidates.Body); err != nil {
 		return res, false, err
 	}
-	if res.Text, err = pickColumn(header, opts.TextColumn, textColumnCandidates); err != nil {
+	if res.Text, err = pickColumn(header, opts.TextColumn, candidates.Text); err != nil {
 		return res, false, err
 	}
 	skipHeader := res.Index.FromHeader || res.Title.FromHeader || res.Body.FromHeader || res.Text.FromHeader
@@ -414,7 +407,8 @@ func resolveCategoryColumn(header []string, explicit string) (int, int, error) {
 		}
 		return idx, start, nil
 	}
-	col := findColumn(header, categoryColumnCandidates)
+	candidates := getColumnCandidates()
+	col := findColumn(header, candidates.Category)
 	start := 0
 	if col >= 0 {
 		start = 1
@@ -497,7 +491,8 @@ func ReadCategoryFileMetadata(path string) (CategoryFileMetadata, error) {
 		header[i] = cleanCell(cell)
 	}
 	meta.Columns = header
-	col := findColumn(header, categoryColumnCandidates)
+	candidates := getColumnCandidates()
+	col := findColumn(header, candidates.Category)
 	if col >= 0 {
 		meta.Suggested = header[col]
 		if meta.Suggested == "" {

--- a/categorizer/types.go
+++ b/categorizer/types.go
@@ -54,14 +54,15 @@ type EmbedderConfig struct {
 
 // Config aggregates runtime settings persisted to config.json.
 type Config struct {
-	Mode      Mode           `json:"mode"`
-	TopK      int            `json:"topK"`
-	SeedBias  float32        `json:"seedBias"`
-	MinScore  float32        `json:"minScore"`
-	Cluster   ClusterConfig  `json:"cluster"`
-	Embedder  EmbedderConfig `json:"embedder"`
-	SeedsPath string         `json:"seedsPath"`
-	UseNDC    bool           `json:"useNdc"`
+	Mode             Mode             `json:"mode"`
+	TopK             int              `json:"topK"`
+	SeedBias         float32          `json:"seedBias"`
+	MinScore         float32          `json:"minScore"`
+	Cluster          ClusterConfig    `json:"cluster"`
+	Embedder         EmbedderConfig   `json:"embedder"`
+	SeedsPath        string           `json:"seedsPath"`
+	UseNDC           bool             `json:"useNdc"`
+	ColumnCandidates ColumnCandidates `json:"columnCandidates"`
 }
 
 // Clone creates a deep copy of the configuration so callers can mutate safely.
@@ -92,4 +93,5 @@ func (c *Config) ApplyDefaults() {
 	if c.Embedder.MaxSeqLen == 0 {
 		c.Embedder.MaxSeqLen = 512
 	}
+	c.ColumnCandidates = c.ColumnCandidates.withDefaults()
 }


### PR DESCRIPTION
## Summary
- add a ColumnCandidates type with setter/getter helpers so auto-detection lists can be overridden
- load column candidate settings from config.json and update CSV parsing to consume the active candidates

## Testing
- `go test ./...` *(fails: module downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d34cadf074832391bbccea4282d8cc