### PR TITLE
Fix CSV output handling for missing directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -1000,11 +1000,12 @@ func saveResultsCSV(outputDir string, records []categorizer.InputRecord, rows []
 	if len(records) != len(rows) {
 		return "", fmt.Errorf("records/results length mismatch: %d vs %d", len(records), len(rows))
 	}
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		return "", fmt.Errorf("create output dir: %w", err)
+	dir, err := ensureOutputDir(outputDir)
+	if err != nil {
+		return "", err
 	}
 	filename := fmt.Sprintf("result_%s.csv", time.Now().Format("200601021504"))
-	path := filepath.Join(outputDir, filename)
+	path := filepath.Join(dir, filename)
 	f, err := os.Create(path)
 	if err != nil {
 		return "", fmt.Errorf("create result file: %w", err)
@@ -1022,6 +1023,21 @@ func saveResultsCSV(outputDir string, records []categorizer.InputRecord, rows []
 		return "", fmt.Errorf("flush result: %w", err)
 	}
 	return path, nil
+}
+
+func ensureOutputDir(outputDir string) (string, error) {
+	dir := strings.TrimSpace(outputDir)
+	if dir == "" {
+		dir = "csv"
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve output dir: %w", err)
+	}
+	if err := os.MkdirAll(absDir, 0o755); err != nil {
+		return "", fmt.Errorf("create output dir %s: %w", absDir, err)
+	}
+	return absDir, nil
 }
 
 func pickBestSuggestion(row categorizer.ResultRow) (categorizer.Suggestion, bool) {


### PR DESCRIPTION
## Summary
- resolve and create the CSV output directory through a shared helper before writing results
- return the absolute path of the generated CSV file so saving succeeds even when the folder did not previously exist

## Testing
- go test ./... *(fails: command hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3775b7f348323b8abacacdfbbcad3