### PR TITLE
Document CLI batch workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,32 @@ Categorizer は、ユーザーが指定したカテゴリシードと日本十�
 7. **設定の調整**
    - 画面右側の設定パネルでモードや閾値を調整すると、即座にサービスへ反映され `config.json` に保存されます。【F:main.go†L241-L342】
 
+### CLI での一括分類
+- GUI を使わずに分類を完結させたい場合は、`--batch-input` と `--category-file` を指定して CLI モードで起動します。【F:main.go†L60-L145】
+- 入力ファイルの列名が標準の `text` や `body` 以外の場合は、`--input-text-column` や `--input-body-column` などのオプションで列を明示すると確実です。【F:main.go†L32-L47】【F:categorizer/io.go†L34-L109】
+- 実行例:
+  ```bash
+  go run . \
+    --batch-input ./inputs.tsv \
+    --category-file ./seeds.csv \
+    --input-text-column "#3" \
+    --output-dir ./csv
+  ```
+- 分類が完了すると `分類結果を <出力パス> に保存しました` が表示され、結果 CSV が `--output-dir`（未指定時は `csv/`）に生成されます。【F:main.go†L139-L144】
+
+## CLI デバッグモード
+- GUI を経由せずにシードの読み込みやテキスト分類を一通り再現したい場合は、`--debug-` 系フラグを付けて CLI モードを起動できます。【F:main.go†L36-L104】【F:main.go†L126-L229】
+- 例: シード CSV を読み込み、正規化済みシードを `seeds_normalized.txt` に書き出した上でテキストファイルを分類し、ログをすべて標準出力に流すには次のコマンドを実行します。
+  ```bash
+  go run . --debug-seed-cli \
+    --debug-seed-file ./seeds.csv \
+    --debug-text-file ./inputs.tsv \
+    --debug-save-results \
+    --debug-seed-output ./seeds_normalized.txt
+  ```
+- `--debug-seed-text` を指定すると CLI から直接入力したシード文字列を利用できます。`--debug-disable-ndc` で NDC 辞書のロードを抑止し、`--output-dir` は `--debug-save-results` と併用したときの CSV 出力先になります。【F:main.go†L36-L104】【F:main.go†L126-L229】
+- デバッグ実行中はサービスが取り込んだ正規化済みシード一覧もログへ出力されるため、GUI フリーズ時にどこまで処理が進んでいるかを CLI で追跡できます。【F:main.go†L155-L196】【F:categorizer/service.go†L92-L134】
+
 ## 設定項目の詳細
 - **Mode** (`seeded` / `mixed` / `split`): シードのみ、シード+NDC 混合、シードと NDC を別リストで提示するモードを選択します。【F:categorizer/types.go†L5-L23】【F:main.go†L241-L254】
 - **Top-K**: 候補数。スライダで 3〜5 の範囲を指定します。【F:main.go†L649-L668】

--- a/categorizer/index.go
+++ b/categorizer/index.go
@@ -61,6 +61,21 @@ func (idx *InMemoryIndex) Size() int {
 	return len(idx.items)
 }
 
+// Items returns a defensive copy of the stored items for inspection/debugging.
+func (idx *InMemoryIndex) Items() []VectorItem {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	out := make([]VectorItem, len(idx.items))
+	for i, it := range idx.items {
+		out[i] = VectorItem{
+			Label:  it.Label,
+			Source: it.Source,
+			Vector: cloneVector(it.Vector),
+		}
+	}
+	return out
+}
+
 // Search performs cosine similarity against all stored items and returns the top-k hits.
 func (idx *InMemoryIndex) Search(vec []float32, k int) []Hit {
 	idx.mu.RLock()

--- a/categorizer/service.go
+++ b/categorizer/service.go
@@ -166,6 +166,16 @@ func (s *Service) SeedCount() int {
 	return s.seedsIdx.Size()
 }
 
+// SeedLabels returns the normalized seed labels currently indexed.
+func (s *Service) SeedLabels() []string {
+	items := s.seedsIdx.Items()
+	labels := make([]string, len(items))
+	for i, it := range items {
+		labels[i] = it.Label
+	}
+	return labels
+}
+
 // ClassifyAll embeds all texts and returns ranked suggestions.
 func (s *Service) ClassifyAll(ctx context.Context, texts []string) ([]ResultRow, error) {
 	start := time.Now()


### PR DESCRIPTION
## Summary
- document how to run the new `--batch-input` CLI workflow in README so users can classify texts without launching the GUI
- add concrete flag examples and notes on column selection for CSV/TSV inputs

## Testing
- go test ./... *(fails: missing OpenGL/X11 development headers required by github.com/go-gl/gl and glfw)*

------
https://chatgpt.com/codex/tasks/task_e_68d392cc45b08323982470649952c9af